### PR TITLE
Add functional python utilities and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,50 @@
-# Build a README with full instructions for using the JSON-defined system locally or through GitHub
+# FRED PRIME Litigation Utilities
 
-readme_content = """
-# 🧠 FRED PRIME Litigation Deployment System
+This repository provides simple Python scripts for managing litigation documents. The tools here allow you to:
 
-This repo enables **offline, token-free litigation automation** for the FRED PRIME system using PowerShell and a JSON-configurable engine.
+- **Auto-label exhibits** in a folder (`Exhibit_A`, `Exhibit_B`, ...)
+- **Link motions to exhibits** by scanning motion text files
+- **Validate signature blocks** according to Michigan Court Rule 1.109(D)(3)
 
----
+These scripts are intentionally lightweight and run entirely offline. They only operate on files you provide and produce markdown summaries for easy review.
 
-## ✅ What This System Does
+## Setup
 
-- 🔖 Auto-labels exhibits (Exhibit A–Z)
-- 🔗 Links motions to matching exhibits
-- 🧾 Validates MCR 1.109(D)(3) signature block compliance
-- 📅 Builds parenting time violation matrix from AppClose logs (Exhibit Y)
-- 🛑 Tracks false police reports and PPO misuse (Exhibit S)
-- ⚖️ Logs judicial irregularities (Exhibit U)
+You need Python 3.8 or newer. Clone the repo and install dependencies (only the standard library is used):
 
----
+```bash
+python3 fredprime.py --help
+```
 
-## 🗂 Structure
+## Usage
 
+### Label exhibits
+Rename all files in a directory sequentially and create `Exhibit_Index.md`:
+
+```bash
+python3 fredprime.py label-exhibits path/to/exhibits
+```
+
+### Link motions to exhibits
+Scan all `.txt` files in a directory for references like `Exhibit A` and build `Motion_to_Exhibit_Map.md`:
+
+```bash
+python3 fredprime.py link-motions path/to/motions
+```
+
+### Validate a signature block
+Check that a document contains a line beginning with `s/` followed by a name:
+
+```bash
+python3 fredprime.py validate-signature path/to/document.txt
+```
+
+## Repository Contents
+
+- `fredprime.py` – command‑line entry point
+- `src/` – module implementations
+  - `exhibit_labeler.py`
+  - `motion_exhibit_linker.py`
+  - `signature_validator.py`
+
+These utilities are minimal examples and may be extended as needed.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository provides simple Python scripts for managing litigation documents
 - **Validate signature blocks** according to Michigan Court Rule 1.109(D)(3)
 
 These scripts are intentionally lightweight and run entirely offline. They only operate on files you provide and produce markdown summaries for easy review.
+Because labeling will rename your files, consider working on copies or using version control to undo changes.
 
 ## Setup
 

--- a/fredprime.py
+++ b/fredprime.py
@@ -1,41 +1,30 @@
 #!/usr/bin/env python3
 """Command-line interface for FRED PRIME helper scripts."""
-import argparse
-from pathlib import Path
-from src.exhibit_labeler import label_exhibits
-from src.motion_exhibit_linker import link_motions
-from src.signature_validator import validate_signature
 
+if __name__ == "__main__":
+    import argparse
+    from src.exhibit_labeler import label_exhibits
+    from src.motion_exhibit_linker import link_motions
+    from src.signature_validator import validate_signature
 
-def main():
-    parser = argparse.ArgumentParser(description="FRED PRIME utilities")
+    parser = argparse.ArgumentParser(description="FRED PRIME Litigation Utility Suite")
     subparsers = parser.add_subparsers(dest="command")
 
-    label = subparsers.add_parser("label-exhibits", help="Rename exhibits A-Z")
-    label.add_argument("exhibit_dir")
-    label.add_argument("--output", default="Exhibit_Index.md")
+    p1 = subparsers.add_parser("label-exhibits")
+    p1.add_argument("path")
 
-    link = subparsers.add_parser("link-motions", help="Map motions to exhibits")
-    link.add_argument("motion_dir")
-    link.add_argument("--output", default="Motion_to_Exhibit_Map.md")
+    p2 = subparsers.add_parser("link-motions")
+    p2.add_argument("path")
 
-    sig = subparsers.add_parser("validate-signature", help="Check document for signature block")
-    sig.add_argument("document")
+    p3 = subparsers.add_parser("validate-signature")
+    p3.add_argument("path")
 
     args = parser.parse_args()
 
     if args.command == "label-exhibits":
-        label_exhibits(args.exhibit_dir, args.output)
+        label_exhibits(args.path)
     elif args.command == "link-motions":
-        link_motions(args.motion_dir, args.output)
+        link_motions(args.path)
     elif args.command == "validate-signature":
-        found = validate_signature(args.document)
-        if found:
-            print("Signature block found")
-        else:
-            print("Signature block not found")
-    else:
-        parser.print_help()
+        print("\u2714 Signature valid" if validate_signature(args.path) else "\u2718 Signature missing")
 
-if __name__ == "__main__":
-    main()

--- a/fredprime.py
+++ b/fredprime.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     from src.signature_validator import validate_signature
 
     parser = argparse.ArgumentParser(description="FRED PRIME Litigation Utility Suite")
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
     p1 = subparsers.add_parser("label-exhibits")
     p1.add_argument("path")

--- a/fredprime.py
+++ b/fredprime.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Command-line interface for FRED PRIME helper scripts."""
+import argparse
+from pathlib import Path
+from src.exhibit_labeler import label_exhibits
+from src.motion_exhibit_linker import link_motions
+from src.signature_validator import validate_signature
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FRED PRIME utilities")
+    subparsers = parser.add_subparsers(dest="command")
+
+    label = subparsers.add_parser("label-exhibits", help="Rename exhibits A-Z")
+    label.add_argument("exhibit_dir")
+    label.add_argument("--output", default="Exhibit_Index.md")
+
+    link = subparsers.add_parser("link-motions", help="Map motions to exhibits")
+    link.add_argument("motion_dir")
+    link.add_argument("--output", default="Motion_to_Exhibit_Map.md")
+
+    sig = subparsers.add_parser("validate-signature", help="Check document for signature block")
+    sig.add_argument("document")
+
+    args = parser.parse_args()
+
+    if args.command == "label-exhibits":
+        label_exhibits(args.exhibit_dir, args.output)
+    elif args.command == "link-motions":
+        link_motions(args.motion_dir, args.output)
+    elif args.command == "validate-signature":
+        found = validate_signature(args.document)
+        if found:
+            print("Signature block found")
+        else:
+            print("Signature block not found")
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/src/exhibit_labeler.py
+++ b/src/exhibit_labeler.py
@@ -1,12 +1,14 @@
-import os
+"""Utility to rename exhibit files sequentially and record an index."""
+
 from pathlib import Path
 from typing import List
 
 
 def label_exhibits(exhibit_dir: str, output_index: str = "Exhibit_Index.md") -> List[str]:
-    """Rename files in exhibit_dir to Exhibit_A, Exhibit_B, ... and produce an index.
+    """Rename files in *exhibit_dir* and create a markdown index.
 
-    Returns a list of new filenames.
+    Files are renamed in alphabetical order as ``Exhibit_A`` etc. The index file
+    lists each renamed exhibit.
     """
     path = Path(exhibit_dir)
     if not path.is_dir():
@@ -22,5 +24,5 @@ def label_exhibits(exhibit_dir: str, output_index: str = "Exhibit_Index.md") -> 
         labeled.append(target.name)
 
     index_lines = [f"- {name}" for name in labeled]
-    Path(output_index).write_text("\n".join(index_lines))
+    Path(output_index).write_text("\n".join(index_lines) + "\n")
     return labeled

--- a/src/exhibit_labeler.py
+++ b/src/exhibit_labeler.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+from typing import List
+
+
+def label_exhibits(exhibit_dir: str, output_index: str = "Exhibit_Index.md") -> List[str]:
+    """Rename files in exhibit_dir to Exhibit_A, Exhibit_B, ... and produce an index.
+
+    Returns a list of new filenames.
+    """
+    path = Path(exhibit_dir)
+    if not path.is_dir():
+        raise ValueError(f"{exhibit_dir} is not a directory")
+
+    files = sorted([p for p in path.iterdir() if p.is_file()])
+    labeled = []
+    for i, file in enumerate(files):
+        label = chr(ord('A') + i)
+        new_name = f"Exhibit_{label}{file.suffix}"
+        target = file.with_name(new_name)
+        file.rename(target)
+        labeled.append(target.name)
+
+    index_lines = [f"- {name}" for name in labeled]
+    Path(output_index).write_text("\n".join(index_lines))
+    return labeled

--- a/src/motion_exhibit_linker.py
+++ b/src/motion_exhibit_linker.py
@@ -1,10 +1,12 @@
+"""Extract exhibit references from motion documents."""
+
 from pathlib import Path
 import re
 from typing import Dict, List
 
 
 def link_motions(motion_dir: str, output_map: str = "Motion_to_Exhibit_Map.md") -> Dict[str, List[str]]:
-    """Scan motion files for exhibit references and produce a map."""
+    """Scan ``motion_dir`` for references like ``Exhibit A`` and record a mapping."""
     motion_path = Path(motion_dir)
     if not motion_path.is_dir():
         raise ValueError(f"{motion_dir} is not a directory")
@@ -22,5 +24,5 @@ def link_motions(motion_dir: str, output_map: str = "Motion_to_Exhibit_Map.md") 
         line = f"- {motion}: {', '.join(exhibits) if exhibits else 'None'}"
         lines.append(line)
 
-    Path(output_map).write_text("\n".join(lines))
+    Path(output_map).write_text("\n".join(lines) + "\n")
     return mapping

--- a/src/motion_exhibit_linker.py
+++ b/src/motion_exhibit_linker.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import re
+from typing import Dict, List
+
+
+def link_motions(motion_dir: str, output_map: str = "Motion_to_Exhibit_Map.md") -> Dict[str, List[str]]:
+    """Scan motion files for exhibit references and produce a map."""
+    motion_path = Path(motion_dir)
+    if not motion_path.is_dir():
+        raise ValueError(f"{motion_dir} is not a directory")
+
+    mapping = {}
+    pattern = re.compile(r"Exhibit\s+([A-Z])")
+
+    for motion_file in motion_path.glob("*.txt"):
+        text = motion_file.read_text(errors="ignore")
+        exhibits = pattern.findall(text)
+        mapping[motion_file.name] = exhibits
+
+    lines = []
+    for motion, exhibits in mapping.items():
+        line = f"- {motion}: {', '.join(exhibits) if exhibits else 'None'}"
+        lines.append(line)
+
+    Path(output_map).write_text("\n".join(lines))
+    return mapping

--- a/src/signature_validator.py
+++ b/src/signature_validator.py
@@ -1,3 +1,5 @@
+"""Simple signature block validator."""
+
 from pathlib import Path
 import re
 
@@ -5,7 +7,7 @@ DEFAULT_PATTERN = re.compile(r"s\/\w+")
 
 
 def validate_signature(document_path: str, pattern: re.Pattern = DEFAULT_PATTERN) -> bool:
-    """Return True if document contains a signature line matching pattern."""
+    """Return ``True`` if *document_path* contains a matching signature line."""
     path = Path(document_path)
     if not path.is_file():
         raise ValueError(f"{document_path} is not a file")

--- a/src/signature_validator.py
+++ b/src/signature_validator.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import re
+
+DEFAULT_PATTERN = re.compile(r"s\/\w+")
+
+
+def validate_signature(document_path: str, pattern: re.Pattern = DEFAULT_PATTERN) -> bool:
+    """Return True if document contains a signature line matching pattern."""
+    path = Path(document_path)
+    if not path.is_file():
+        raise ValueError(f"{document_path} is not a file")
+
+    text = path.read_text(errors="ignore")
+    return bool(pattern.search(text))


### PR DESCRIPTION
## Summary
- clean up README with usable instructions
- implement exhibit labeling, motion/exhibit linking and signature validation scripts
- provide command line entry point `fredprime.py`

## Testing
- `python3 -m py_compile fredprime.py src/*.py`
- `python3 fredprime.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686d84f9676083229c78386cc6c51e19