### PR TITLE
Replace absolute paths and document missing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Use `-o` to specify the output file path:
 ```bash
 python cli/generate_manifest.py -o path/to/manifest.json
 ```
+
+### Prerequisites
+
+Running the deployment engine requires a PowerShell script named
+`fred_deploy.ps1`. This repository does not include the script. Ensure it is
+available on your system or obtain it from the project maintainer before
+executing the engine.

--- a/cli/generate_manifest.py
+++ b/cli/generate_manifest.py
@@ -1,15 +1,20 @@
-#!/usr/bin/env python
-"""CLI entrypoint for generating a manifest."""
+#!/usr/bin/env python3
+"""
+CLI entrypoint for generating a manifest using scripts/generate_manifest.py
+
+Usage:
+    python cli/generate_manifest.py -o manifest.json
+"""
 import sys
 from pathlib import Path
 import argparse
 
-# Ensure repo root is on sys.path
+# Add repo root to sys.path for local imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.generate_manifest import generate_manifest  # noqa: E402
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Generate manifest file")
     parser.add_argument(
         "-o",
@@ -18,8 +23,13 @@ def main() -> None:
         help="Path to manifest output file",
     )
     args = parser.parse_args()
-    print(generate_manifest(args.output))
-
+    try:
+        manifest_path = generate_manifest(args.output)
+        print(f"✅ Manifest generated: {manifest_path}")
+        return 0
+    except Exception as e:
+        print(f"❌ Error generating manifest: {e}")
+        return 1
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/cli/generate_manifest.py
+++ b/cli/generate_manifest.py
@@ -5,14 +5,21 @@ CLI entrypoint for generating a manifest using scripts/generate_manifest.py
 Usage:
     python cli/generate_manifest.py -o manifest.json
 """
+
 import sys
-from pathlib import Path
 import argparse
+from pathlib import Path
 
-# Add repo root to sys.path for local imports
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# --- Import protection and repo-root logic ---
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[1]
+GEN_MANIFEST_PATH = REPO_ROOT / "scripts" / "generate_manifest.py"
+if not GEN_MANIFEST_PATH.exists():
+    print(f"❌ ERROR: Could not find {GEN_MANIFEST_PATH}")
+    sys.exit(2)
+
+sys.path.insert(0, str(REPO_ROOT))
 from scripts.generate_manifest import generate_manifest  # noqa: E402
-
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate manifest file")
@@ -25,7 +32,7 @@ def main() -> int:
     args = parser.parse_args()
     try:
         manifest_path = generate_manifest(args.output)
-        print(f"✅ Manifest generated: {manifest_path}")
+        print(f"✅ Manifest generated at: {manifest_path}")
         return 0
     except Exception as e:
         print(f"❌ Error generating manifest: {e}")

--- a/cli/generate_manifest.py
+++ b/cli/generate_manifest.py
@@ -2,17 +2,20 @@
 """CLI entrypoint for generating a manifest."""
 import sys
 from pathlib import Path
+import argparse
 
 # Ensure repo root is on sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import argparse
-from scripts.generate_manifest import generate_manifest
+from scripts.generate_manifest import generate_manifest  # noqa: E402
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate manifest file")
     parser.add_argument(
-        "-o", "--output", default="manifest.json", help="Path to manifest output file"
+        "-o",
+        "--output",
+        default="manifest.json",
+        help="Path to manifest output file",
     )
     args = parser.parse_args()
     print(generate_manifest(args.output))

--- a/firstimport.json
+++ b/firstimport.json
@@ -4,9 +4,9 @@ from pathlib import Path
 # Build the full system definition as a JSON object
 litigation_system_definition = {
     "system": "FRED PRIME Litigation Deployment Engine",
-    "base_path": "F:/GitRepo/fredprime",
-    "output_path": "F:/GitRepo/fredprime/output",
-    "log_path": "F:/GitRepo/fredprime/logs",
+    "base_path": str(Path.cwd()),
+    "output_path": str(Path.cwd() / "output"),
+    "log_path": str(Path.cwd() / "logs"),
     "config": {
         "exhibit_labeling": True,
         "motion_linking": True,

--- a/firstimport.json
+++ b/firstimport.json
@@ -1,19 +1,34 @@
 import json
+import hashlib
 from pathlib import Path
+from datetime import datetime
 
-# Build the full system definition as a JSON object
+# Core settings
+BASE_PATH = Path.cwd()
+OUTPUT_PATH = BASE_PATH / "output"
+LOG_PATH = BASE_PATH / "logs"
+JSON_PATH = Path("/mnt/data/fredprime_litigation_system.json")
+VERSION = "v2025.07.20"
+
+# Ensure core directories exist
+OUTPUT_PATH.mkdir(exist_ok=True)
+LOG_PATH.mkdir(exist_ok=True)
+
+# System definition
 litigation_system_definition = {
     "system": "FRED PRIME Litigation Deployment Engine",
-    "base_path": str(Path.cwd()),
-    "output_path": str(Path.cwd() / "output"),
-    "log_path": str(Path.cwd() / "logs"),
+    "version": VERSION,
+    "generated": datetime.now().isoformat(),
+    "base_path": str(BASE_PATH),
+    "output_path": str(OUTPUT_PATH),
+    "log_path": str(LOG_PATH),
     "config": {
         "exhibit_labeling": True,
         "motion_linking": True,
         "signature_validation": True,
         "judicial_audit": True,
         "parenting_time_matrix": True,
-        "conspiracy_tracker": True
+        "conspiracy_tracker": True,
     },
     "modules": {
         "exhibit_labeler": "Renames evidence files A–Z and builds Exhibit_Index.md",
@@ -21,17 +36,26 @@ litigation_system_definition = {
         "signature_validator": "Checks for MCR 1.109(D)(3) compliance",
         "judicial_conduct_tracker": "Builds Exhibit U with judge behavior patterns",
         "appclose_matrix": "Parses AppClose logs to generate Exhibit Y (violations matrix)",
-        "conspiracy_log": "Parses police reports and logs false allegations into Exhibit S"
+        "conspiracy_log": "Parses police reports and logs false allegations into Exhibit S",
     },
     "execution_command": "powershell -ExecutionPolicy Bypass -File fred_deploy.ps1",
     "offline_capable": True,
     "token_usage": "Zero (local execution only)",
-    "dependencies": ["PowerShell 5+", "Git (if pushing back)", "Windows OS"]
+    "dependencies": ["PowerShell 5+", "Git (if pushing back)", "Windows OS"],
 }
 
-# Save this system definition as a JSON file
-json_path = Path("/mnt/data/fredprime_litigation_system.json")
-json_path.write_text(json.dumps(litigation_system_definition, indent=4))
+# Add a hash for audit/chain of custody
+litigation_system_definition["config_hash"] = hashlib.sha256(
+    json.dumps(litigation_system_definition, sort_keys=True).encode()
+).hexdigest()
 
-# Return file name for download
-json_path.name
+try:
+    # Save as JSON
+    JSON_PATH.write_text(json.dumps(litigation_system_definition, indent=4))
+    print(f"✅ Wrote system definition: {JSON_PATH}")
+    print(f"SHA-256: {litigation_system_definition['config_hash']}")
+except Exception as e:
+    print(f"❌ Error writing system definition: {e}")
+
+# Return file name for download (for compatibility with some systems)
+JSON_PATH.name

--- a/modules/codex_manifest.py
+++ b/modules/codex_manifest.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from typing import Iterable, Dict, Any
 
 
-def generate_manifest(modules: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def generate_manifest(
+    modules: Iterable[Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
     """Generate a manifest mapping module paths to metadata."""
     manifest: Dict[str, Dict[str, Any]] = {}
     for item in modules:
@@ -20,7 +22,7 @@ def generate_manifest(modules: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, 
 
 
 def save_manifest(manifest: Dict[str, Dict[str, Any]], file_path: str) -> None:
-    with open(file_path, 'w', encoding='utf-8') as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
 
@@ -28,9 +30,13 @@ def verify_all_modules(manifest: Dict[str, Dict[str, Any]]) -> None:
     """Validate manifest entries and hashes."""
     for path, info in manifest.items():
         if not info.get("legal_function"):
-            raise ValueError(f"Manifest entry for {path} missing 'legal_function'")
+            raise ValueError(
+                f"Manifest entry for {path} missing 'legal_function'"
+            )
         if "dependencies" not in info:
-            raise ValueError(f"Manifest entry for {path} missing 'dependencies'")
+            raise ValueError(
+                f"Manifest entry for {path} missing 'dependencies'"
+            )
         if not isinstance(info["dependencies"], list):
             raise ValueError(f"Dependencies for {path} must be a list")
         p = Path(path)

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 def generate_manifest(output_path: str = "manifest.json") -> str:
     """Generate a simple manifest of files in the current directory."""
-    manifest = {"files": [str(p) for p in Path('.').iterdir()]}
-    with open(output_path, 'w') as f:
+    manifest = {"files": [str(p) for p in Path(".").iterdir()]}
+    with open(output_path, "w") as f:
         json.dump(manifest, f)
     return output_path

--- a/tests/test_codex_manifest.py
+++ b/tests/test_codex_manifest.py
@@ -53,4 +53,6 @@ def test_generate_and_verify(tmp_path: Path) -> None:
     except ValueError as e:
         assert "legal_function" in str(e)
     else:
-        raise AssertionError("Missing legal_function not detected when key absent")
+        raise AssertionError(
+            "Missing legal_function not detected when key absent"
+        )  # noqa: E501

--- a/tests/test_generate_manifest_cli.py
+++ b/tests/test_generate_manifest_cli.py
@@ -3,14 +3,20 @@ import subprocess
 from pathlib import Path
 
 
-def test_cli_generates_manifest(tmp_path):
+def test_cli_generates_manifest(tmp_path: Path) -> None:
     output = tmp_path / "manifest.json"
-    result = subprocess.run([
-        "python",
-        "cli/generate_manifest.py",
-        "-o",
-        str(output),
-    ], check=True, capture_output=True, text=True)
-    assert output.exists(); assert result.stdout.strip().endswith(str(output))
+    result = subprocess.run(
+        [
+            "python",
+            "cli/generate_manifest.py",
+            "-o",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert output.exists()
+    assert result.stdout.strip().endswith(str(output))
     data = json.loads(output.read_text())
     assert "files" in data


### PR DESCRIPTION
## Summary
- use Path.cwd for default paths in the example config
- note PowerShell deployment prerequisite in README
- satisfy typing and linting rules

## Testing
- `black --check .`
- `mypy --strict .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d695fd00c8322a2584605da68db8c