### PR TITLE
Update manifest CLI test to use sys.executable

### DIFF
--- a/tests/test_generate_manifest_cli.py
+++ b/tests/test_generate_manifest_cli.py
@@ -1,16 +1,22 @@
 import json
 import subprocess
-from pathlib import Path
+import sys
 
 
 def test_cli_generates_manifest(tmp_path):
     output = tmp_path / "manifest.json"
-    result = subprocess.run([
-        "python",
-        "cli/generate_manifest.py",
-        "-o",
-        str(output),
-    ], check=True, capture_output=True, text=True)
-    assert output.exists(); assert result.stdout.strip().endswith(str(output))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli/generate_manifest.py",
+            "-o",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert output.exists()
+    assert result.stdout.strip().endswith(str(output))
     data = json.loads(output.read_text())
     assert "files" in data


### PR DESCRIPTION
## Summary
- use `sys.executable` instead of string `'python'`
- adjust imports in manifest CLI test

## Testing
- `black tests/test_generate_manifest_cli.py`
- `mypy tests/test_generate_manifest_cli.py`
- `flake8 tests/test_generate_manifest_cli.py`
- `pytest -q tests/test_generate_manifest_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_687db1baa5e0832280e2d5d2f0428375