### PR TITLE
Fix JSON script path creation

### DIFF
--- a/firstimport.json
+++ b/firstimport.json
@@ -31,6 +31,7 @@ litigation_system_definition = {
 
 # Save this system definition as a JSON file
 json_path = Path("/mnt/data/fredprime_litigation_system.json")
+json_path.parent.mkdir(parents=True, exist_ok=True)
 json_path.write_text(json.dumps(litigation_system_definition, indent=4))
 
 # Return file name for download


### PR DESCRIPTION
## Summary
- ensure `/mnt/data` directory exists when saving JSON

## Testing
- `python3 firstimport.json`

------
https://chatgpt.com/codex/tasks/task_e_6840f475f39483229f01439fbade29d9