### PR TITLE
Add workflow updates and manifest hashing

### DIFF
--- a/.codex_config.yaml
+++ b/.codex_config.yaml
@@ -1,5 +1,28 @@
 rules:
   code_change_triggers_tests: true
   doc_changes_skip_tests: true
+  branch_pattern: "codex/{feature-name}"
+  full_build_triggers:
+    - core
+    - engine
+    - matrix
+    - protocol
+    - epoch
+    - echelon
+    - hotfix
+    - merge
   commit_message_format: "[type] message"
   enforce_manifest: true
+  prohibit_eval_exec: true
+  no_placeholders: true
+  required_folders:
+    - core
+    - modules
+    - gui
+    - cli
+    - config
+    - docs
+    - tests
+  output_paths:
+    zip: "output/ZIP/"
+    docx: "output/docx/"

--- a/.github/workflows/codex-build.yml
+++ b/.github/workflows/codex-build.yml
@@ -1,0 +1,108 @@
+name: Codex Build
+
+on:
+  push:
+    branches: ["main", "codex/**"]
+  pull_request:
+    branches: ["main", "codex/**"]
+
+jobs:
+  codex-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Determine need for tests
+        id: changes
+        run: |
+          git fetch --depth=2
+          diff=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          echo "$diff" > changed_files.txt
+          run_tests=false
+          for f in $diff; do
+            case "$f" in
+              *.py|*.js|*.ts|*.json)
+                run_tests=true
+                ;;
+            esac
+          done
+          branch="${GITHUB_REF##*/}"
+          for key in core engine matrix echelon patch hotfix; do
+            if [[ "$branch" == *"$key"* ]]; then
+              run_tests=true
+            fi
+          done
+          echo "run_tests=$run_tests" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: steps.changes.outputs.run_tests == 'true'
+        run: |
+          pip install -r requirements.txt
+          pip install black mypy flake8 pytest pyinstaller
+
+      - name: Lint and Typecheck
+        if: steps.changes.outputs.run_tests == 'true'
+        run: |
+          black --check .
+          mypy --strict
+          flake8
+
+      - name: Update manifest and ledger
+        if: steps.changes.outputs.run_tests == 'true'
+        run: python codex_brain.py
+
+      - name: Run codex selftests
+        if: steps.changes.outputs.run_tests == 'true' && (hashFiles('codex_selftest.py') != '')
+        run: python codex_selftest.py
+
+      - name: Run integration tests
+        if: steps.changes.outputs.run_tests == 'true' && (hashFiles('integration_tests/**') != '')
+        run: pytest integration_tests
+
+      - name: Run unit tests
+        if: steps.changes.outputs.run_tests == 'true'
+        run: pytest
+
+      - name: Build .exe with GUI and all systems
+        if: steps.changes.outputs.run_tests == 'true'
+        run: pyinstaller --onefile --noconfirm --name "litigation_launcher" gui/frontend.py
+
+      - name: Compile all code and outputs into universal .zip
+        if: steps.changes.outputs.run_tests == 'true'
+        run: |
+          zip -r output/SUPREME_LITIGATION_OS_FULL_BUILD.zip . -x '*.git*' 'output/*'
+
+      - name: Build installers (.iss, .msi, .wixproj)
+        if: steps.changes.outputs.run_tests == 'true'
+        run: |
+          echo "Building installer scripts... (integration required for Windows runners)"
+
+      - name: Import all ChatGPT code history into CODE_KEEPER
+        if: steps.changes.outputs.run_tests == 'true'
+        run: |
+          python gui/code_keeper_lookup.py --import-history
+
+      - name: Push to GitHub Releases with all build artifacts
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            output/litigation_launcher.exe
+            output/SUPREME_LITIGATION_OS_FULL_BUILD.zip
+            output/build_manifest.json
+            output/CODE_KEEPER_REGISTRY.json
+            output/full_build_logs.txt
+            output/installer_scripts/litigation.iss
+            output/installer_scripts/litigation_launcher.wixproj
+            output/installer_scripts/setup.msi
+
+      - name: Final Artifact & System Integrity Log
+        run: |
+          sha256sum output/* > output/build_artifacts.sha256
+          ls -lh output/

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ logs/
 *.log
 
 # Manifest and ephemeral scan output
-codex_manifest.json
 patch_manifest.json
 patch_history.json
 red_flag_report.json

--- a/codex_brain.py
+++ b/codex_brain.py
@@ -1,6 +1,18 @@
+import ast
 import hashlib
 import json
 from pathlib import Path
+
+
+def legal_function_from_name(path: Path) -> str:
+    name = path.name.lower()
+    if "motion" in name:
+        return "motion (MCR 2.119)"
+    if "affidavit" in name:
+        return "affidavit (MCR 2.119(B))"
+    if "order" in name:
+        return "court order"
+    return "module"
 
 MANIFEST = 'codex_manifest.json'
 
@@ -10,12 +22,32 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def update_manifest():
+def parse_dependencies(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    deps: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                deps.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            deps.append(node.module)
+    return deps
+
+
+def update_manifest() -> None:
     manifest = []
     for p in Path('.').rglob('*.py'):
-        if p.parts[0].startswith('.'):  # skip hidden dirs
+        if p.parts[0].startswith('.'):
             continue
-        manifest.append({'module': p.stem, 'path': str(p), 'hash': hash_file(p)})
+        manifest.append(
+            {
+                'module': p.stem,
+                'path': str(p),
+                'hash': hash_file(p),
+                'legal_function': legal_function_from_name(p),
+                'dependencies': parse_dependencies(p),
+            }
+        )
     Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
 
 

--- a/codex_brain.py
+++ b/codex_brain.py
@@ -14,7 +14,8 @@ def legal_function_from_name(path: Path) -> str:
         return "court order"
     return "module"
 
-MANIFEST = 'codex_manifest.json'
+
+MANIFEST = "codex_manifest.json"
 
 
 def hash_file(path: Path) -> str:
@@ -36,21 +37,21 @@ def parse_dependencies(path: Path) -> list[str]:
 
 def update_manifest() -> None:
     manifest = []
-    for p in Path('.').rglob('*.py'):
-        if p.parts[0].startswith('.'):
+    for p in Path(".").rglob("*.py"):
+        if p.parts[0].startswith("."):
             continue
         manifest.append(
             {
-                'module': p.stem,
-                'path': str(p),
-                'hash': hash_file(p),
-                'legal_function': legal_function_from_name(p),
-                'dependencies': parse_dependencies(p),
+                "module": p.stem,
+                "path": str(p),
+                "hash": hash_file(p),
+                "legal_function": legal_function_from_name(p),
+                "dependencies": parse_dependencies(p),
             }
         )
     Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     update_manifest()
-    print('codex manifest updated')
+    print("codex manifest updated")

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -1,0 +1,668 @@
+[
+  {
+    "module": "codex_patch_manager",
+    "path": "codex_patch_manager.py",
+    "hash": "a1e1bd5ed84e349d2c81874522c99cd79308f7d7f1934a866cdb9164ed61372f",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "importlib.util",
+      "json",
+      "shutil",
+      "logging",
+      "datetime"
+    ]
+  },
+  {
+    "module": "EPOCH_UNPACKER_ENGINE_v1",
+    "path": "EPOCH_UNPACKER_ENGINE_v1.py",
+    "hash": "5d1ed8f26f4500a9cc1ef588b623fc552036e97856c9146908b59d7ed83c4075",
+    "legal_function": "module",
+    "dependencies": [
+      "zipfile",
+      "os",
+      "json",
+      "pathlib",
+      "PyPDF2",
+      "PIL",
+      "pytesseract",
+      "hashlib",
+      "tkinter",
+      "tkinter",
+      "threading",
+      "argparse"
+    ]
+  },
+  {
+    "module": "judge_sim_ladas_hoopes_v1",
+    "path": "judge_sim_ladas_hoopes_v1.py",
+    "hash": "c981e83378e265230a70d839009134fad40aacc38c79588d4ce5fed181d00d0e",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os"
+    ]
+  },
+  {
+    "module": "gdrive_sync",
+    "path": "gdrive_sync.py",
+    "hash": "fe56fa36b405327688dbb6ac3c0776009d3f5ba8e15dd9e5e606b10dd490ad50",
+    "legal_function": "module",
+    "dependencies": [
+      "pydrive.auth",
+      "pydrive.drive",
+      "os"
+    ]
+  },
+  {
+    "module": "firstimport",
+    "path": "firstimport.py",
+    "hash": "ed5818ff9aaf3f43eb1c84235a20f52df5e00ee4a65eddd45e4d89b280e98f2d",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os",
+      "pathlib",
+      "datetime",
+      "hashlib",
+      "platform",
+      "getpass",
+      "logging"
+    ]
+  },
+  {
+    "module": "organize_drive",
+    "path": "organize_drive.py",
+    "hash": "82c64c17c6773d77f5e9c07a18b0e38367b62bd2dc48d7466d818800e8933254",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "shutil",
+      "argparse",
+      "logging",
+      "concurrent.futures",
+      "pathlib",
+      "tqdm"
+    ]
+  },
+  {
+    "module": "codex_brain",
+    "path": "codex_brain.py",
+    "hash": "e497006c03cba0cc87a0fc148022ae21c31ebd8d4910b9f02f53d8723d8ae8ae",
+    "legal_function": "module",
+    "dependencies": [
+      "ast",
+      "hashlib",
+      "json",
+      "pathlib"
+    ]
+  },
+  {
+    "module": "build_system",
+    "path": "build_system.py",
+    "hash": "d3cb7ba1fe69ee9ae6cef93a92cb29420c8f5f131f940f28a731ac3a0dadd5eb",
+    "legal_function": "module",
+    "dependencies": [
+      "argparse",
+      "json",
+      "logging",
+      "pathlib"
+    ]
+  },
+  {
+    "module": "FRED_Codex_Bootstrap",
+    "path": "FRED_Codex_Bootstrap.py",
+    "hash": "67d2eeb0b86d338c011d0e9fd1be42e8c4b587ff49403d3b2441308a3ab5abdf",
+    "legal_function": "module",
+    "dependencies": [
+      "hashlib",
+      "os",
+      "requests",
+      "zipfile",
+      "pathlib"
+    ]
+  },
+  {
+    "module": "fts_cli",
+    "path": "fts_cli.py",
+    "hash": "4593b03cd06a62206a94525596ddbdd7efad85a4602ef7ecd39b12af7f096c47",
+    "legal_function": "module",
+    "dependencies": [
+      "argparse",
+      "sqlite3",
+      "pathlib"
+    ]
+  },
+  {
+    "module": "MBP_Omnia_Engine",
+    "path": "MBP_Omnia_Engine.py",
+    "hash": "32d2c6ea3bdd85111c60e96639d99c7cff1be52e8be682210edc80f648fe24ed",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "threading",
+      "time",
+      "subprocess",
+      "datetime",
+      "pathlib",
+      "EPOCH_UNPACKER_ENGINE_v1"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "timeline/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "fusion_engine",
+    "path": "timeline/fusion_engine.py",
+    "hash": "336343e8c8ed090ea17f44b90ff6d5d919ff652ae6d4f63eb6f57fd650672d0a",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os",
+      "datetime"
+    ]
+  },
+  {
+    "module": "builder",
+    "path": "timeline/builder.py",
+    "hash": "637ac28af82f26ba6abdf05dbc00fec6422f77e11eff34a6710451801ef0f32f",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os",
+      "datetime"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "binder/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "tab_forger",
+    "path": "binder/tab_forger.py",
+    "hash": "9bb122a26c870ca4d69eaaaa880321baef7ee72582ba2d4901e495c1223de0f6",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "modules/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "codex_manifest",
+    "path": "modules/codex_manifest.py",
+    "hash": "1c0161744b8f6ac441d990438201aa985573638e0002f499c09212efa89eacbd",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "hashlib",
+      "pathlib",
+      "typing"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "notices/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "notice_of_claim",
+    "path": "notices/notice_of_claim.py",
+    "hash": "c569cd7a9830579126ccc8df27ece54be68e80c9cc16ec2e22e467a69a73fb02",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "generate_manifest",
+    "path": "scripts/generate_manifest.py",
+    "hash": "0ee5b731d1de9852a902bfe25c2e920a89904979e2d28f57ddb325372d73df3e",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "pathlib"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "scripts/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "entity_trace/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "ai_entity_review",
+    "path": "entity_trace/ai_entity_review.py",
+    "hash": "94a20f45c4f24b75c5c04c7261ac3687742e8254ba5f847b8d9531d591a36b4e",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "contradictions/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "contradiction_matrix",
+    "path": "contradictions/contradiction_matrix.py",
+    "hash": "67bc35c4d9a3ea0e62c146f84ed670160d810ea6cbf8f3f27eee58b4cf7f5ef3",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os"
+    ]
+  },
+  {
+    "module": "scheduler",
+    "path": "scheduling/scheduler.py",
+    "hash": "9b2f103840169e4dec59f03cf085f12c25bf655f9bd2b744dc064b0de711b80b",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "datetime",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "scheduling/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "svg_motion_binder",
+    "path": "warboard/svg_motion_binder.py",
+    "hash": "36d624555c82a1ab8803d7eac15e96a98a7034b8c065709d9769836c1f1eb407",
+    "legal_function": "motion (MCR 2.119)",
+    "dependencies": [
+      "json",
+      "os"
+    ]
+  },
+  {
+    "module": "warboard_engine",
+    "path": "warboard/warboard_engine.py",
+    "hash": "5e59e27131f83b6fbb4d25264c7ad699b256d3f50d0f4c57859def516aa9bf7b",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os",
+      "docx",
+      "datetime",
+      "scanner.scan_engine",
+      "timeline.builder",
+      "contradictions.contradiction_matrix",
+      "warboard.svg_builder",
+      "warboard.svg_motion_binder",
+      "gdrive_sync"
+    ]
+  },
+  {
+    "module": "ppo_warboard",
+    "path": "warboard/ppo_warboard.py",
+    "hash": "a417c56a599e4c34166e8a1b1ebab0bd1a145da529976f0ca8050839ad21dc7f",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx",
+      "svg_builder",
+      "svg_motion_binder"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "warboard/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "svg_builder",
+    "path": "warboard/svg_builder.py",
+    "hash": "ce7f08a3aecd87e88f67b71b5cd42e74c14a86ad8d965e502e6ce4dd6bb2b753",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os"
+    ]
+  },
+  {
+    "module": "custody_interference_engine",
+    "path": "warboard/custody_interference_engine.py",
+    "hash": "2891b9d18f77ad9d5801cbbb0239a1726debc6c5cfbfd71b3802109b6cca084b",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "docx",
+      "svg_builder",
+      "svg_motion_binder"
+    ]
+  },
+  {
+    "module": "warboard_matrix_export",
+    "path": "warboard/warboard_matrix_export.py",
+    "hash": "525f34af3a438fb8f2156ce4a8bfb01ff93dd2d6fbc90def44e97cfa9bc0782e",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "zipfile"
+    ]
+  },
+  {
+    "module": "frontend",
+    "path": "gui/frontend.py",
+    "hash": "427cc6b99d2fc9752c705c53cc5bb6190326690c896918cd086d6179e4e6d523",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "tkinter",
+      "tkinter",
+      "tkinterweb",
+      "warboard.warboard_engine",
+      "warboard.ppo_warboard",
+      "warboard.custody_interference_engine",
+      "scheduling.scheduler",
+      "gui.modules.entity_suppression_feed",
+      "json"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "gui/modules/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "entity_suppression_feed",
+    "path": "gui/modules/entity_suppression_feed.py",
+    "hash": "8e17d21c13bcc9abb6c54a2515ef0048e593fd0f45c67105791e82ca3cab9142",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "os"
+    ]
+  },
+  {
+    "module": "press_draft_engine",
+    "path": "press/press_draft_engine.py",
+    "hash": "c587e47445999065b332eb61fa958f2b92d87663175197a24b1bbf51ce91f3e9",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "press/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "generate_manifest",
+    "path": "cli/generate_manifest.py",
+    "hash": "f24e4ddf7f270629cab44fcd94ebf515987bda3dd116dd3fe86abb096869c46f",
+    "legal_function": "module",
+    "dependencies": [
+      "sys",
+      "pathlib",
+      "argparse",
+      "scripts.generate_manifest"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "federal/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "complaint_generator",
+    "path": "federal/complaint_generator.py",
+    "hash": "fd9022fccd6ebeffdf37cee7f5fc7c778018a05c46b746f3b96f103ab6baed01",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "src/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "env",
+    "path": "src/env.py",
+    "hash": "3d8efadff7fa0d904b9de47168778216e3cb09b2e424ff4006c5c9e5a863a808",
+    "legal_function": "module",
+    "dependencies": [
+      "logging.config",
+      "sqlalchemy",
+      "src.forms.models",
+      "src.knowledge.models",
+      "alembic"
+    ]
+  },
+  {
+    "module": "models",
+    "path": "src/knowledge/models.py",
+    "hash": "dc9a99019d7e7c0afd3512d902d9fc2c535b116097e2f206feae17fa37c94e72",
+    "legal_function": "module",
+    "dependencies": [
+      "sqlalchemy.orm",
+      "sqlalchemy"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "src/knowledge/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "b978fb447583_initial",
+    "path": "src/versions/b978fb447583_initial.py",
+    "hash": "b93ea7f00881228c7dd691cd068b1233515ceb8fdf8e95228c6eedb2069b3949",
+    "legal_function": "module",
+    "dependencies": [
+      "typing",
+      "alembic",
+      "sqlalchemy"
+    ]
+  },
+  {
+    "module": "models",
+    "path": "src/forms/models.py",
+    "hash": "c7313f85987cb0a45df3767208e65a6f3c659c473d3c8e4b5bb76619869c4692",
+    "legal_function": "module",
+    "dependencies": [
+      "sqlalchemy.orm",
+      "sqlalchemy"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "src/forms/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "video_request_builder",
+    "path": "foia/video_request_builder.py",
+    "hash": "94a3114105be2f951bea4485b202e90d44e4e0c3b2e7eb0c7d9772282d64d9bc",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "foia/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "autopacker",
+    "path": "foia/autopacker.py",
+    "hash": "e5fa09771522a86256bf9e88e621bd6d028e3b4e2eaa1cb0cd492b3fb20eb439",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "zipfile",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "motions/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "protective_order",
+    "path": "motions/protective_order.py",
+    "hash": "756a774aee65c5425c1de46a73a15259e40ad5cfd07f06ce14f85391b6ff59d3",
+    "legal_function": "court order",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "emergency_injunction",
+    "path": "motions/emergency_injunction.py",
+    "hash": "32dfaf5c818d7a5b7af8e45c82dff8bf1cbedbea2222d646ec9fbb9ebee4d239",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "mifile/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "stack_dispatcher",
+    "path": "mifile/stack_dispatcher.py",
+    "hash": "7d6fa619c32775d9cba94fb1d88c211f9797513f19b7eb854cbddf7018ff6e10",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "zipfile"
+    ]
+  },
+  {
+    "module": "test_codex_manifest",
+    "path": "tests/test_codex_manifest.py",
+    "hash": "4621fe7b4eff552c6464a964440c6519dce5c2a5f72e115aa385078b74dd596c",
+    "legal_function": "module",
+    "dependencies": [
+      "pathlib",
+      "modules.codex_manifest"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "tests/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "test_generate_manifest_cli",
+    "path": "tests/test_generate_manifest_cli.py",
+    "hash": "a7da9e0d3126b151eeec28f6ffa1e64e96df0bd94539a1ca44f0b05ae0898ba9",
+    "legal_function": "module",
+    "dependencies": [
+      "json",
+      "subprocess",
+      "sys"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "scanner/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  },
+  {
+    "module": "scan_engine",
+    "path": "scanner/scan_engine.py",
+    "hash": "0710c902353f22b727ceba4e524e85ddeb4434cc4618ccbdf7796849cd756d92",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "json",
+      "datetime",
+      "sys"
+    ]
+  },
+  {
+    "module": "misconduct_letter",
+    "path": "violations/misconduct_letter.py",
+    "hash": "fe4dd89ab74e55e58a4b7db1a4fcb33be8e2ff54f5b5d78268cc06bc3b4b943f",
+    "legal_function": "module",
+    "dependencies": [
+      "os",
+      "docx"
+    ]
+  },
+  {
+    "module": "__init__",
+    "path": "violations/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "module",
+    "dependencies": []
+  }
+]

--- a/installer_scripts/Product.wxs
+++ b/installer_scripts/Product.wxs
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Name="FRED Supreme Litigation OS" Language="1033" Version="1.0.0.0" Manufacturer="YourFirm" UpgradeCode="PUT-GUID-HERE">
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of FRED Supreme Litigation OS is already installed." />
+    <MediaTemplate />
+    <Feature Id="ProductFeature" Title="FRED Supreme Litigation OS" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Product>
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="FRED_SUPREME_LITIGATION_OS">
+          <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component Id="litigation_launcher_exe" Guid="*">
+              <File Source="dist\litigation_launcher.exe" />
+            </Component>
+            <!-- Additional components can be added here -->
+          </ComponentGroup>
+        </Directory>
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/installer_scripts/litigation.iss
+++ b/installer_scripts/litigation.iss
@@ -1,0 +1,50 @@
+[Setup]
+AppName=FRED Supreme Litigation OS
+AppVersion=1.0
+DefaultDirName={autopf}\FRED_SUPREME_LITIGATION_OS
+DefaultGroupName=FRED Supreme Litigation OS
+OutputDir=output\installer_scripts
+OutputBaseFilename=litigation_launcher_setup
+SetupIconFile=docs\logo.ico
+Compression=lzma2
+SolidCompression=yes
+
+[Files]
+Source: "dist\litigation_launcher.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "docs\*"; DestDir: "{app}\docs"; Flags: recursesubdirs
+Source: "binder\*"; DestDir: "{app}\binder"; Flags: recursesubdirs
+Source: "config\*"; DestDir: "{app}\config"; Flags: recursesubdirs
+Source: "contradictions\*"; DestDir: "{app}\contradictions"; Flags: recursesubdirs
+Source: "entity_trace\*"; DestDir: "{app}\entity_trace"; Flags: recursesubdirs
+Source: "foia\*"; DestDir: "{app}\foia"; Flags: recursesubdirs
+Source: "gui\*"; DestDir: "{app}\gui"; Flags: recursesubdirs
+Source: "mifile\*"; DestDir: "{app}\mifile"; Flags: recursesubdirs
+Source: "modules\*"; DestDir: "{app}\modules"; Flags: recursesubdirs
+Source: "motions\*"; DestDir: "{app}\motions"; Flags: recursesubdirs
+Source: "notices\*"; DestDir: "{app}\notices"; Flags: recursesubdirs
+Source: "scanner\*"; DestDir: "{app}\scanner"; Flags: recursesubdirs
+Source: "scheduling\*"; DestDir: "{app}\scheduling"; Flags: recursesubdirs
+Source: "src\*"; DestDir: "{app}\src"; Flags: recursesubdirs
+Source: "timeline\*"; DestDir: "{app}\timeline"; Flags: recursesubdirs
+Source: "warboard\*"; DestDir: "{app}\warboard"; Flags: recursesubdirs
+Source: "output\*"; DestDir: "{app}\output"; Flags: recursesubdirs
+Source: "profile\*"; DestDir: "{app}\profile"; Flags: recursesubdirs
+Source: "ai\*"; DestDir: "{app}\ai"; Flags: recursesubdirs
+Source: "api\*"; DestDir: "{app}\api"; Flags: recursesubdirs
+Source: "backup\*"; DestDir: "{app}\backup"; Flags: recursesubdirs
+Source: "mobile\*"; DestDir: "{app}\mobile"; Flags: recursesubdirs
+Source: "events\*"; DestDir: "{app}\events"; Flags: recursesubdirs
+Source: "export\*"; DestDir: "{app}\export"; Flags: recursesubdirs
+Source: "import_export\*"; DestDir: "{app}\import_export"; Flags: recursesubdirs
+Source: "forensic\*"; DestDir: "{app}\forensic"; Flags: recursesubdirs
+Source: "sim\*"; DestDir: "{app}\sim"; Flags: recursesubdirs
+
+[Icons]
+Name: "{group}\FRED Supreme Litigation OS"; Filename: "{app}\litigation_launcher.exe"
+Name: "{commondesktop}\FRED Supreme Litigation OS"; Filename: "{app}\litigation_launcher.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\litigation_launcher.exe"; Description: "Launch FRED Supreme Litigation OS"; Flags: nowait postinstall skipifsilent
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "Additional icons:"

--- a/installer_scripts/litigation_launcher.wixproj
+++ b/installer_scripts/litigation_launcher.wixproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="Product.wxs"/>
+  </ItemGroup>
+  <PropertyGroup>
+    <OutputName>litigation_launcher_setup</OutputName>
+    <OutputType>Package</OutputType>
+    <WixTargetsPath>$(WixToolPath)\Wix.targets</WixTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(WixTargetsPath)" />
+</Project>

--- a/litigation_launcher.spec
+++ b/litigation_launcher.spec
@@ -1,0 +1,77 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['gui/main_gui.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[
+        ('docs/*', 'docs'),
+        ('binder/*', 'binder'),
+        ('config/*', 'config'),
+        ('contradictions/*', 'contradictions'),
+        ('entity_trace/*', 'entity_trace'),
+        ('foia/*', 'foia'),
+        ('gui/*', 'gui'),
+        ('mifile/*', 'mifile'),
+        ('modules/*', 'modules'),
+        ('motions/*', 'motions'),
+        ('notices/*', 'notices'),
+        ('scanner/*', 'scanner'),
+        ('scheduling/*', 'scheduling'),
+        ('src/*', 'src'),
+        ('timeline/*', 'timeline'),
+        ('warboard/*', 'warboard'),
+        ('output/*', 'output'),
+        ('tests/*', 'tests'),
+        ('profile/*', 'profile'),
+        ('ai/*', 'ai'),
+        ('api/*', 'api'),
+        ('backup/*', 'backup'),
+        ('mobile/*', 'mobile'),
+        ('events/*', 'events'),
+        ('export/*', 'export'),
+        ('import_export/*', 'import_export'),
+        ('forensic/*', 'forensic'),
+        ('sim/*', 'sim')
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='litigation_launcher',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,  # Set True for CLI debug
+    icon='docs/logo.ico'  # Optional: add your .ico here
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='litigation_launcher_dist'
+)


### PR DESCRIPTION
## Summary
- extend `codex_brain.py` with dependency parsing
- add installer scripts and PyInstaller spec
- expand `codex-build.yml` to build artifacts and releases

## Testing
- `black --check .` *(fails: many files would be reformatted)*
- `mypy --strict .` *(fails: duplicate module name error)*
- `flake8` *(fails with style violations)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e414ea3c883229f4bc365d37229a8