### PR TITLE
[core] Extract module metadata for manifest

### DIFF
--- a/codex_brain.py
+++ b/codex_brain.py
@@ -1,9 +1,11 @@
 import hashlib
 import json
 from pathlib import Path
+from typing import Tuple
 
 from modules.codex_guardian import run_guardian
 from modules.codex_supreme import self_diagnostic
+from modules.codex_manifest import generate_manifest, verify_all_modules
 
 MANIFEST = "codex_manifest.json"
 
@@ -13,13 +15,75 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def update_manifest():
-    manifest = []
+def extract_metadata(path: Path) -> Tuple[str, list[str]]:
+    """Extract legal metadata from a module.
+
+    The function looks for either a sibling ``*.meta.json`` file or
+    header comments in the source. Comments should take the form::
+
+        # legal_function: short description
+        # dependencies: pkg1, pkg2
+
+    Args:
+        path: Module path.
+
+    Returns:
+        A tuple containing the legal function description and a list of
+        dependency names.
+    """
+
+    legal_function = "unknown"
+    dependencies: list[str] = []
+    meta_path = path.with_suffix(".meta.json")
+
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text())
+            legal_function = meta.get("legal_function", legal_function)
+            dependencies = meta.get("dependencies", dependencies)
+        except json.JSONDecodeError:
+            pass
+
+    if legal_function == "unknown" or not dependencies:
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for _ in range(10):
+                    line = f.readline()
+                    if not line:
+                        break
+                    lower = line.lower()
+                    if lower.startswith("# legal_function:"):
+                        legal_function = line.split(":", 1)[1].strip()
+                    elif lower.startswith("# dependencies:"):
+                        deps = line.split(":", 1)[1]
+                        dependencies = [d.strip() for d in deps.split(",") if d.strip()]
+                    if legal_function != "unknown" and dependencies:
+                        break
+        except OSError:
+            pass
+
+    return legal_function, dependencies
+
+
+def update_manifest() -> None:
+    modules: list[dict[str, object]] = []
     for p in Path(".").rglob("*.py"):
-        if p.parts[0].startswith("."):  # skip hidden dirs
+        if p.parts[0].startswith("."):
             continue
-        manifest.append({"module": p.stem, "path": str(p), "hash": hash_file(p)})
-    Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
+        legal_function, dependencies = extract_metadata(p)
+        modules.append(
+            {
+                "module": p.stem,
+                "path": str(p),
+                "hash": hash_file(p),
+                "legal_function": legal_function,
+                "dependencies": dependencies,
+            }
+        )
+
+    manifest_map = generate_manifest(modules)
+    verify_all_modules(manifest_map)
+    Path(MANIFEST).write_text(json.dumps(modules, indent=2))
 
 
 def main() -> None:

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -1,9 +1,576 @@
 [
   {
+    "module": "organize_drive",
+    "path": "organize_drive.py",
+    "hash": "82c64c17c6773d77f5e9c07a18b0e38367b62bd2dc48d7466d818800e8933254",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "litigation_os_generate_motion (1)",
+    "path": "litigation_os_generate_motion (1).py",
+    "hash": "484481b86921ccaa68052be7a29349b0d81b0b6f00138a6049755150fb06fc51",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "Build_And_Upload_Master_Litigation_Pack_Z",
+    "path": "Build_And_Upload_Master_Litigation_Pack_Z.py",
+    "hash": "705101039d9dcff2071c1a933dc413ec36f4890cc600477906de42c54648285b",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "FRED_Codex_Bootstrap",
+    "path": "FRED_Codex_Bootstrap.py",
+    "hash": "67d2eeb0b86d338c011d0e9fd1be42e8c4b587ff49403d3b2441308a3ab5abdf",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "build_system",
+    "path": "build_system.py",
+    "hash": "d3cb7ba1fe69ee9ae6cef93a92cb29420c8f5f131f940f28a731ac3a0dadd5eb",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "MBP_Omnia_Engine",
+    "path": "MBP_Omnia_Engine.py",
+    "hash": "32d2c6ea3bdd85111c60e96639d99c7cff1be52e8be682210edc80f648fe24ed",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "ZIP_VALIDATOR",
+    "path": "ZIP_VALIDATOR.py",
+    "hash": "9a62a2c672416e2fafc3a5325bfb7a84458757abf72b9e24d4b17fc68e8224c5",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "LITIGATION_CORE_ENGINE_v9999",
+    "path": "LITIGATION_CORE_ENGINE_v9999.py",
+    "hash": "8b212e7cb2e7a93c6d3ca6e5cdda5600d52ea48baebbf0d1f393bde4f5f4994e",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "EPOCH_UNPACKER_ENGINE_v1",
+    "path": "EPOCH_UNPACKER_ENGINE_v1.py",
+    "hash": "5d1ed8f26f4500a9cc1ef588b623fc552036e97856c9146908b59d7ed83c4075",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "judge_sim_ladas_hoopes_v1",
+    "path": "judge_sim_ladas_hoopes_v1.py",
+    "hash": "c981e83378e265230a70d839009134fad40aacc38c79588d4ce5fed181d00d0e",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "litigation_core_engine_v_9999_full",
+    "path": "litigation_core_engine_v_9999_full.py",
+    "hash": "cef6737b0644613eb524d11c1480a08fa4287a9e451cdd086e15a27a9feb26b9",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "gdrive_sync",
+    "path": "gdrive_sync.py",
+    "hash": "fe56fa36b405327688dbb6ac3c0776009d3f5ba8e15dd9e5e606b10dd490ad50",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "codex_patch_manager",
+    "path": "codex_patch_manager.py",
+    "hash": "a1e1bd5ed84e349d2c81874522c99cd79308f7d7f1934a866cdb9164ed61372f",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "codex_brain",
+    "path": "codex_brain.py",
+    "hash": "841e78e2aad4bd1cc32bc8b8e60417966b9536d81c0af9b67d994a5927487e11",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "LITIGATION_CORE_ENGINE_v9999 (1)",
+    "path": "LITIGATION_CORE_ENGINE_v9999 (1).py",
+    "hash": "1f94871df920434d262e8d055c34f00dfe790abdcf6f31228f9c159e701fb795",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "tarball",
+    "path": "tarball.py",
+    "hash": "50c2c8b75a53f4042c9c71e79eb4dd69e8a8b8d85148aec6c2107509f429493d",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "BINDER_BUILDER",
+    "path": "BINDER_BUILDER.py",
+    "hash": "dd33a0484431edcff051e7fbb7a9ab35a4aa8ad24a21ba2dfa93da43d7431668",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "LITIGATION_CORE_ENGINE_v9999 (2)",
+    "path": "LITIGATION_CORE_ENGINE_v9999 (2).py",
+    "hash": "8c37f48cc658d033fd3d90150e6e931dce89e2e5989429f5c80db75e511938fc",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "firstimport",
+    "path": "firstimport.py",
+    "hash": "ed5818ff9aaf3f43eb1c84235a20f52df5e00ee4a65eddd45e4d89b280e98f2d",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "openAIkey",
+    "path": "openAIkey.py",
+    "hash": "49da163bedd0e1317a3e750deb3c2e27e0062da03d55866c1aa5f51b67a1d588",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "DOCUMENT_NEEDS_ENGINE_v9999",
+    "path": "DOCUMENT_NEEDS_ENGINE_v9999.py",
+    "hash": "db0c6d5f0af6677cde41db695c95c013b940366db0e274673526ebc4c6173c54",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "fts_cli",
+    "path": "fts_cli.py",
+    "hash": "4593b03cd06a62206a94525596ddbdd7efad85a4602ef7ecd39b12af7f096c47",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "scanner/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "scan_engine",
+    "path": "scanner/scan_engine.py",
+    "hash": "0710c902353f22b727ceba4e524e85ddeb4434cc4618ccbdf7796849cd756d92",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "test_codex_guardian",
+    "path": "tests/test_codex_guardian.py",
+    "hash": "3e98cdc408ebde71c1e9661cbbd7038f4530d96c751e358c7e3367cf6e077a46",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "test_codex_manifest",
+    "path": "tests/test_codex_manifest.py",
+    "hash": "4621fe7b4eff552c6464a964440c6519dce5c2a5f72e115aa385078b74dd596c",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "tests/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "test_benchbook_loader",
+    "path": "tests/test_benchbook_loader.py",
+    "hash": "205a4e4ddcef6817daabf0a518fadc848fc917e0a51cf7c070fa36e10d08aa7b",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "test_codex_supreme",
+    "path": "tests/test_codex_supreme.py",
+    "hash": "228b1184d54483a8c99f77ba23172e0814a83b32c4e062527f29f984edc0618c",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "test_generate_manifest_cli",
+    "path": "tests/test_generate_manifest_cli.py",
+    "hash": "a7da9e0d3126b151eeec28f6ffa1e64e96df0bd94539a1ca44f0b05ae0898ba9",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "press/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "press_draft_engine",
+    "path": "press/press_draft_engine.py",
+    "hash": "c587e47445999065b332eb61fa958f2b92d87663175197a24b1bbf51ce91f3e9",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "frontend",
+    "path": "gui/frontend.py",
+    "hash": "427cc6b99d2fc9752c705c53cc5bb6190326690c896918cd086d6179e4e6d523",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "gui/modules/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "entity_suppression_feed",
+    "path": "gui/modules/entity_suppression_feed.py",
+    "hash": "8e17d21c13bcc9abb6c54a2515ef0048e593fd0f45c67105791e82ca3cab9142",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "emergency_injunction",
+    "path": "motions/emergency_injunction.py",
+    "hash": "32dfaf5c818d7a5b7af8e45c82dff8bf1cbedbea2222d646ec9fbb9ebee4d239",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "motions/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "protective_order",
+    "path": "motions/protective_order.py",
+    "hash": "756a774aee65c5425c1de46a73a15259e40ad5cfd07f06ce14f85391b6ff59d3",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "generate_manifest",
+    "path": "cli/generate_manifest.py",
+    "hash": "f24e4ddf7f270629cab44fcd94ebf515987bda3dd116dd3fe86abb096869c46f",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "stack_dispatcher",
+    "path": "mifile/stack_dispatcher.py",
+    "hash": "7d6fa619c32775d9cba94fb1d88c211f9797513f19b7eb854cbddf7018ff6e10",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "mifile/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "ai_entity_review",
+    "path": "entity_trace/ai_entity_review.py",
+    "hash": "94a20f45c4f24b75c5c04c7261ac3687742e8254ba5f847b8d9531d591a36b4e",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "entity_trace/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "binder/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "tab_forger",
+    "path": "binder/tab_forger.py",
+    "hash": "9bb122a26c870ca4d69eaaaa880321baef7ee72582ba2d4901e495c1223de0f6",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "codex_supreme",
+    "path": "modules/codex_supreme.py",
+    "hash": "efc26e08c86bf1a61a2d2fc9cb7c6ea3786ae5a0e34e686834fe793e9c52b3be",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "modules/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "codex_guardian",
+    "path": "modules/codex_guardian.py",
+    "hash": "896ddfe7d7196d394879299b8df5a0ecea7fa97985795b5dd4f475819c10a98d",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "codex_manifest",
+    "path": "modules/codex_manifest.py",
+    "hash": "1c0161744b8f6ac441d990438201aa985573638e0002f499c09212efa89eacbd",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
     "module": "benchbook_loader",
     "path": "modules/benchbook_loader.py",
     "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
-    "legal_function": "extract text from Michigan benchbook PDFs",
-    "dependencies": ["PyPDF2"]
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "scheduling/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "scheduler",
+    "path": "scheduling/scheduler.py",
+    "hash": "9b2f103840169e4dec59f03cf085f12c25bf655f9bd2b744dc064b0de711b80b",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "warboard/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "custody_interference_engine",
+    "path": "warboard/custody_interference_engine.py",
+    "hash": "2891b9d18f77ad9d5801cbbb0239a1726debc6c5cfbfd71b3802109b6cca084b",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "ppo_warboard",
+    "path": "warboard/ppo_warboard.py",
+    "hash": "a417c56a599e4c34166e8a1b1ebab0bd1a145da529976f0ca8050839ad21dc7f",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "warboard_matrix_export",
+    "path": "warboard/warboard_matrix_export.py",
+    "hash": "525f34af3a438fb8f2156ce4a8bfb01ff93dd2d6fbc90def44e97cfa9bc0782e",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "svg_builder",
+    "path": "warboard/svg_builder.py",
+    "hash": "ce7f08a3aecd87e88f67b71b5cd42e74c14a86ad8d965e502e6ce4dd6bb2b753",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "warboard_engine",
+    "path": "warboard/warboard_engine.py",
+    "hash": "5e59e27131f83b6fbb4d25264c7ad699b256d3f50d0f4c57859def516aa9bf7b",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "svg_motion_binder",
+    "path": "warboard/svg_motion_binder.py",
+    "hash": "36d624555c82a1ab8803d7eac15e96a98a7034b8c065709d9769836c1f1eb407",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "env",
+    "path": "src/env.py",
+    "hash": "3d8efadff7fa0d904b9de47168778216e3cb09b2e424ff4006c5c9e5a863a808",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "src/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "src/knowledge/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "models",
+    "path": "src/knowledge/models.py",
+    "hash": "dc9a99019d7e7c0afd3512d902d9fc2c535b116097e2f206feae17fa37c94e72",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "src/forms/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "models",
+    "path": "src/forms/models.py",
+    "hash": "c7313f85987cb0a45df3767208e65a6f3c659c473d3c8e4b5bb76619869c4692",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "b978fb447583_initial",
+    "path": "src/versions/b978fb447583_initial.py",
+    "hash": "b93ea7f00881228c7dd691cd068b1233515ceb8fdf8e95228c6eedb2069b3949",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "complaint_generator",
+    "path": "federal/complaint_generator.py",
+    "hash": "fd9022fccd6ebeffdf37cee7f5fc7c778018a05c46b746f3b96f103ab6baed01",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "federal/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "video_request_builder",
+    "path": "foia/video_request_builder.py",
+    "hash": "94a3114105be2f951bea4485b202e90d44e4e0c3b2e7eb0c7d9772282d64d9bc",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "foia/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "autopacker",
+    "path": "foia/autopacker.py",
+    "hash": "e5fa09771522a86256bf9e88e621bd6d028e3b4e2eaa1cb0cd492b3fb20eb439",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "notices/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "notice_of_claim",
+    "path": "notices/notice_of_claim.py",
+    "hash": "c569cd7a9830579126ccc8df27ece54be68e80c9cc16ec2e22e467a69a73fb02",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "contradiction_matrix",
+    "path": "contradictions/contradiction_matrix.py",
+    "hash": "67bc35c4d9a3ea0e62c146f84ed670160d810ea6cbf8f3f27eee58b4cf7f5ef3",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "contradictions/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "generate_manifest",
+    "path": "scripts/generate_manifest.py",
+    "hash": "0ee5b731d1de9852a902bfe25c2e920a89904979e2d28f57ddb325372d73df3e",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "scripts/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "violations/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "misconduct_letter",
+    "path": "violations/misconduct_letter.py",
+    "hash": "fe4dd89ab74e55e58a4b7db1a4fcb33be8e2ff54f5b5d78268cc06bc3b4b943f",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "fusion_engine",
+    "path": "timeline/fusion_engine.py",
+    "hash": "336343e8c8ed090ea17f44b90ff6d5d919ff652ae6d4f63eb6f57fd650672d0a",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "builder",
+    "path": "timeline/builder.py",
+    "hash": "637ac28af82f26ba6abdf05dbc00fec6422f77e11eff34a6710451801ef0f32f",
+    "legal_function": "unknown",
+    "dependencies": []
+  },
+  {
+    "module": "__init__",
+    "path": "timeline/__init__.py",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "legal_function": "unknown",
+    "dependencies": []
   }
 ]


### PR DESCRIPTION
## Summary
- parse module header comments or sidecar metadata to capture `legal_function` and `dependencies`
- validate entries with `codex_manifest` utilities before persisting manifest

## Testing
- `black codex_brain.py`
- `mypy --strict --follow-imports=skip codex_brain.py`
- `flake8 codex_brain.py`
- `pytest`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest integration_tests` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27830200083228a61ce7176f8ac81