### PR TITLE
[core] Add meek pipeline launcher and test

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -5,5 +5,12 @@
     "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
     "legal_function": "extract text from Michigan benchbook PDFs",
     "dependencies": ["PyPDF2"]
+  },
+  {
+    "module": "meek_pipeline_launcher",
+    "path": "scripts/meek_pipeline_launcher.py",
+    "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
+    "legal_function": "launch ingestion and search pipeline",
+    "dependencies": ["meek_ingest_cli", "fts_cli"]
   }
 ]

--- a/scripts/meek_pipeline_launcher.py
+++ b/scripts/meek_pipeline_launcher.py
@@ -1,0 +1,48 @@
+import argparse
+
+
+def run_ingest() -> None:
+    """Run the ingestion stage."""
+    from meek_ingest_cli import main as ingest_main
+
+    ingest_main()
+
+
+def run_search(query: str) -> None:
+    """Run the search stage."""
+    from fts_cli import search_records
+
+    search_records(query)
+
+
+def run_post_process() -> None:
+    """Run optional post-processing/report generation."""
+    print("Post-processing complete.")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the Meek ingestion and search pipeline."""
+    parser = argparse.ArgumentParser(description="Meek pipeline launcher")
+    parser.add_argument(
+        "--skip-ingest", action="store_true", help="Skip ingestion stage"
+    )
+    parser.add_argument("--skip-search", action="store_true", help="Skip search stage")
+    parser.add_argument("--search-query", help="Query string for search")
+    parser.add_argument(
+        "--post-process", action="store_true", help="Run post-processing stage"
+    )
+    args = parser.parse_args(argv)
+
+    if not args.skip_ingest:
+        run_ingest()
+
+    if not args.skip_search:
+        query = args.search_query or input("Enter search query: ")
+        run_search(query)
+
+    if args.post_process:
+        run_post_process()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/meek_pipeline_launcher_test.py
+++ b/tests/meek_pipeline_launcher_test.py
@@ -1,0 +1,29 @@
+import sys
+import types
+from typing import Any
+
+from scripts import meek_pipeline_launcher
+
+
+def test_pipeline_sequential_run(monkeypatch: Any) -> None:
+    calls: list[str] = []
+
+    ingest_mod: Any = types.ModuleType("meek_ingest_cli")
+
+    def ingest_main() -> None:
+        calls.append("ingest")
+
+    ingest_mod.main = ingest_main
+    monkeypatch.setitem(sys.modules, "meek_ingest_cli", ingest_mod)
+
+    fts_mod: Any = types.ModuleType("fts_cli")
+
+    def search_records(query: str) -> None:
+        calls.append(query)
+
+    fts_mod.search_records = search_records
+    monkeypatch.setitem(sys.modules, "fts_cli", fts_mod)
+
+    meek_pipeline_launcher.main(["--search-query", "dummy"])
+
+    assert calls == ["ingest", "dummy"]


### PR DESCRIPTION
## Summary
- add `meek_pipeline_launcher` script to orchestrate ingestion, search, and optional post-processing
- track new module in `codex_manifest.json`
- add unit test for pipeline launcher

## Testing
- `python -m black scripts/meek_pipeline_launcher.py tests/meek_pipeline_launcher_test.py`
- `python -m mypy --strict --ignore-missing-imports --follow-imports=skip scripts/meek_pipeline_launcher.py tests/meek_pipeline_launcher_test.py`
- `python -m flake8 scripts/meek_pipeline_launcher.py tests/meek_pipeline_launcher_test.py`
- `python -m pytest -q`
- `python codex_selftest.py` *(fails: file not found)*
- `python -m pytest integration_tests -q` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a704053f7483228f71d1117fbe18bb