### PR TITLE
Refine manifest typing in guardian and supreme modules

### DIFF
--- a/modules/codex_guardian.py
+++ b/modules/codex_guardian.py
@@ -1,9 +1,9 @@
 import hashlib
 import json
-import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any, cast
 
 MANIFEST_FILE = "codex_manifest.json"
 BANNED_KEYWORDS = ["TODO", "WIP", "temp_var", "placeholder"]
@@ -25,10 +25,10 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def load_manifest() -> list[dict]:
+def load_manifest() -> list[dict[str, Any]]:
     if Path(MANIFEST_FILE).exists():
-        return json.loads(Path(MANIFEST_FILE).read_text())
-    return []
+        return cast(list[dict[str, Any]], json.loads(Path(MANIFEST_FILE).read_text()))
+    return cast(list[dict[str, Any]], [])
 
 
 def verify_commit_message(msg: str) -> None:

--- a/modules/codex_supreme.py
+++ b/modules/codex_supreme.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from typing import Any, cast
 
 PERSISTENT_STATE_FILE = "codex_state.json"
 AUDIT_LOG = "audit_chain.log"
@@ -11,7 +12,7 @@ ERROR_LOG = "logs/codex_errors.log"
 PATCH_HISTORY = "patch_history.json"
 
 
-def sha256_file(fpath: str) -> str:
+def sha256_file(fpath: str | Path) -> str:
     try:
         return hashlib.sha256(Path(fpath).read_bytes()).hexdigest()
     except Exception:
@@ -25,15 +26,15 @@ def log_event(event: str, log_file: str = AUDIT_LOG) -> None:
         f.write(f"{ts} {hval} {event}\n")
 
 
-def save_state(state: dict, state_file: str = PERSISTENT_STATE_FILE) -> None:
+def save_state(state: dict[str, Any], state_file: str = PERSISTENT_STATE_FILE) -> None:
     with open(state_file, "w") as f:
         json.dump(state, f, indent=2)
 
 
-def load_state(state_file: str = PERSISTENT_STATE_FILE) -> dict:
+def load_state(state_file: str = PERSISTENT_STATE_FILE) -> dict[str, Any]:
     if os.path.exists(state_file):
         with open(state_file) as f:
-            return json.load(f)
+            return cast(dict[str, Any], json.load(f))
     return {}
 
 
@@ -56,7 +57,7 @@ def self_diagnostic() -> list[str]:
 
 
 def forensic_integrity_check() -> list[str]:
-    issues = []
+    issues: list[str] = []
     if not os.path.exists(MANIFEST_FILE):
         return issues
     manifest = json.loads(Path(MANIFEST_FILE).read_text())
@@ -68,7 +69,7 @@ def forensic_integrity_check() -> list[str]:
     return issues
 
 
-def timeline_event_matrix() -> list[dict]:
+def timeline_event_matrix() -> list[dict[str, Any]]:
     timeline = []
     if os.path.exists(MANIFEST_FILE):
         manifest = json.loads(Path(MANIFEST_FILE).read_text())


### PR DESCRIPTION
## Summary
- annotate manifest loader in codex_guardian with explicit `list[dict[str, Any]]` typing
- clarify generic dict usage in codex_supreme with `dict[str, Any]` and improved hash checks

## Testing
- `black modules/codex_guardian.py modules/codex_supreme.py`
- `flake8 modules/codex_guardian.py modules/codex_supreme.py`
- `mypy --strict modules/codex_guardian.py modules/codex_supreme.py`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0e53d9408322b38d9be2d036fb03