### PR TITLE
Parallelize drive scanning with ThreadPoolExecutor

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -5,5 +5,12 @@
     "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
     "legal_function": "extract text from Michigan benchbook PDFs",
     "dependencies": ["PyPDF2"]
+  },
+  {
+    "module": "scan_engine",
+    "path": "scanner/scan_engine.py",
+    "hash": "fabbdb2bc979bcf3faa1f7419c6c3bfc1b3740bce6e7e9341e52885e0df8d836",
+    "legal_function": "scan drives for legal files",
+    "dependencies": []
   }
 ]

--- a/scanner/scan_engine.py
+++ b/scanner/scan_engine.py
@@ -1,46 +1,83 @@
 import os
 import json
+import logging
+import threading
+import concurrent.futures
 from datetime import datetime
+from typing import Dict, List, Optional
 
-DEFAULT_OUTPUT = os.path.join('data', 'scan_index.json')
-
-
-def scan_directory(root_dir: str, index: dict) -> None:
-    for dirpath, _, filenames in os.walk(root_dir):
-        for name in filenames:
-            if name.lower().endswith(('.docx', '.pdf', '.txt')):
-                path = os.path.join(dirpath, name)
-                try:
-                    created = datetime.fromtimestamp(os.path.getctime(path)).isoformat()
-                    index[path] = {'created': created}
-                except OSError:
-                    pass
+DEFAULT_OUTPUT = os.path.join("data", "scan_index.json")
 
 
-def run_scan(drives=None, output: str = DEFAULT_OUTPUT) -> None:
+logging.basicConfig(level=logging.INFO, format="%(threadName)s: %(message)s")
+_index_lock = threading.Lock()
+
+
+def scan_drive(root_dir: str) -> Dict[str, Dict[str, str]]:
+    """Scan ``root_dir`` using an explicit stack and return an index of files."""
+    index: Dict[str, Dict[str, str]] = {}
+    stack = [root_dir]
+    while stack:
+        current = stack.pop()
+        try:
+            for entry in os.scandir(current):
+                if entry.is_dir(follow_symlinks=False):
+                    stack.append(entry.path)
+                elif entry.is_file() and entry.name.lower().endswith(
+                    (".docx", ".pdf", ".txt")
+                ):
+                    try:
+                        created = datetime.fromtimestamp(
+                            os.path.getctime(entry.path)
+                        ).isoformat()
+                        index[entry.path] = {"created": created}
+                        logging.info("Match: %s", entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+    return index
+
+
+def run_scan(drives: Optional[List[str]] = None, output: str = DEFAULT_OUTPUT) -> None:
     """Scan the provided drives and write an index of legal files."""
 
     if drives is None:
-        env_drives = os.getenv('SCAN_DRIVES')
+        env_drives = os.getenv("SCAN_DRIVES")
         if env_drives:
             drives = env_drives.split(os.pathsep)
         else:
-            drives = ['F:/', 'D:/']
+            drives = ["F:/", "D:/"]
 
-    index = {}
-    for drive in drives:
-        if os.path.exists(drive):
-            scan_directory(drive, index)
-        else:
-            print(f'Skip missing drive: {drive}')
+    index: dict[str, dict[str, str]] = {}
+
+    existing = [d for d in drives if os.path.exists(d)]
+    missing = [d for d in drives if not os.path.exists(d)]
+    for drive in missing:
+        logging.info("Skip missing drive: %s", drive)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_drive = {
+            executor.submit(scan_drive, drive): drive for drive in existing
+        }
+        for future in concurrent.futures.as_completed(future_to_drive):
+            drive = future_to_drive[future]
+            try:
+                result = future.result()
+                with _index_lock:
+                    index.update(result)
+                logging.info("Completed scan: %s (%d files)", drive, len(result))
+            except Exception as exc:  # pragma: no cover - log unexpected errors
+                logging.error("%s generated an exception: %s", drive, exc)
 
     os.makedirs(os.path.dirname(output), exist_ok=True)
-    with open(output, 'w') as f:
+    with open(output, "w") as f:
         json.dump(index, f, indent=2)
-    print(f'Scan complete. Indexed {len(index)} files to {output}')
+    logging.info("Scan complete. Indexed %d files to %s", len(index), output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
+
     drives = sys.argv[1:] or None
     run_scan(drives)


### PR DESCRIPTION
## Summary
- parallelize drive scanning with `ThreadPoolExecutor`
- log matches as they are found and merge results safely
- record `scan_engine` in `codex_manifest.json`

## Testing
- `black scanner/scan_engine.py`
- `mypy --strict scanner/scan_engine.py`
- `flake8 scanner/scan_engine.py`
- `pytest`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest integration_tests` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ababc4a34c83229429eb07ddd208af