### PR TITLE
Add unified litigator CLI

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Command-line utilities for FRED PRIME litigation system."""
+
+__all__ = ["ingest", "build", "validate"]

--- a/cli/build.py
+++ b/cli/build.py
@@ -1,0 +1,19 @@
+"""Build operations for litigator CLI."""
+
+from pathlib import Path
+
+from typing import cast
+
+from build_system import build_json as _build_json
+
+
+def run(output: Path) -> Path:
+    """Generate the litigation system definition JSON.
+
+    Args:
+        output: Destination path for the generated JSON file.
+
+    Returns:
+        The path to the generated file.
+    """
+    return cast(Path, _build_json(output))

--- a/cli/ingest.py
+++ b/cli/ingest.py
@@ -1,0 +1,26 @@
+"""Ingestion operations for litigator CLI."""
+
+from pathlib import Path
+from typing import Optional
+
+from typing import Callable, cast
+
+from EPOCH_UNPACKER_ENGINE_v1 import (
+    run_headless as _run_headless,
+    set_base_dir as _set_base_dir,
+)
+
+run_headless = cast(Callable[[str], None], _run_headless)
+set_base_dir = cast(Callable[[Path], None], _set_base_dir)
+
+
+def run(zip_path: Path, base_dir: Optional[Path] = None) -> None:
+    """Process an evidentiary ZIP archive.
+
+    Args:
+        zip_path: Path to the ZIP file to process.
+        base_dir: Directory where extracted data and logs will reside.
+    """
+    if base_dir is not None:
+        set_base_dir(base_dir)
+    run_headless(str(zip_path))

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -1,0 +1,18 @@
+"""Validation operations for litigator CLI."""
+
+from pathlib import Path
+
+from typing import Callable, cast
+
+from ZIP_VALIDATOR import validate_zip_folder as _validate_zip_folder
+
+validate_zip_folder = cast(Callable[[str], None], _validate_zip_folder)
+
+
+def run(base_path: Path) -> None:
+    """Validate required files before creating a ZIP archive.
+
+    Args:
+        base_path: Directory containing litigation files.
+    """
+    validate_zip_folder(str(base_path))

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -1,9 +1,37 @@
 [
-  {
-    "module": "benchbook_loader",
-    "path": "modules/benchbook_loader.py",
-    "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
-    "legal_function": "extract text from Michigan benchbook PDFs",
-    "dependencies": ["PyPDF2"]
-  }
+    {
+        "module": "benchbook_loader",
+        "path": "modules/benchbook_loader.py",
+        "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
+        "legal_function": "extract text from Michigan benchbook PDFs",
+        "dependencies": ["PyPDF2"],
+    },
+    {
+        "module": "litigator_cli",
+        "path": "litigator_cli.py",
+        "hash": "3f3dd0a60bc0c37e36006f31e402894f468488f64e5850d4868dcd0a73245a45",
+        "legal_function": "Unified command-line interface for ingesting, building, and validating litigation data",
+        "dependencies": ["argparse", "cli.ingest", "cli.build", "cli.validate"],
+    },
+    {
+        "module": "ingest",
+        "path": "cli/ingest.py",
+        "hash": "740e7ac03b295cb97a59286d968f768451ce631f07403d6b0cacabb7a3e454cc",
+        "legal_function": "Process evidentiary ZIP archives",
+        "dependencies": ["EPOCH_UNPACKER_ENGINE_v1"],
+    },
+    {
+        "module": "build",
+        "path": "cli/build.py",
+        "hash": "053bc45cec4818d3ad7d1b0b4803e30a5e4e56cb721316c10b07ec7d140d5374",
+        "legal_function": "Generate litigation system definition JSON",
+        "dependencies": ["build_system"],
+    },
+    {
+        "module": "validate",
+        "path": "cli/validate.py",
+        "hash": "2e43d9de0c50edbe07775d2f4ce487936f10b6c509b21dc9d2343588dba6e217",
+        "legal_function": "Ensure required files exist before packaging",
+        "dependencies": ["ZIP_VALIDATOR"],
+    },
 ]

--- a/litigator_cli.py
+++ b/litigator_cli.py
@@ -1,0 +1,50 @@
+"""Unified command-line interface for litigation tasks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from cli.build import run as build_run
+from cli.ingest import run as ingest_run
+from cli.validate import run as validate_run
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Litigator command-line interface")
+    sub = parser.add_subparsers(dest="command")
+
+    ingest_p = sub.add_parser("ingest", help="Process an evidentiary ZIP archive")
+    ingest_p.add_argument("zip_path", type=Path, help="Path to the ZIP archive")
+    ingest_p.add_argument(
+        "--base-dir",
+        type=Path,
+        default=None,
+        help="Directory for extracted files and logs",
+    )
+
+    build_p = sub.add_parser("build", help="Generate litigation system definition JSON")
+    build_p.add_argument("output", type=Path, help="Destination for the JSON file")
+
+    validate_p = sub.add_parser(
+        "validate", help="Ensure required files exist before zipping"
+    )
+    validate_p.add_argument(
+        "base_path", type=Path, help="Directory containing litigation files"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        ingest_run(args.zip_path, args.base_dir)
+    elif args.command == "build":
+        path = build_run(args.output)
+        print(path)
+    elif args.command == "validate":
+        validate_run(args.base_path)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - direct execution guard
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ packages = find:
 [options.entry_points]
 console_scripts =
     generate_manifest = cli.generate_manifest:main
+    litigator = litigator_cli:main
 
 [flake8]
 max-line-length = 120

--- a/tests/test_litigator_cli.py
+++ b/tests/test_litigator_cli.py
@@ -1,0 +1,38 @@
+"""Tests for the unified litigator CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from ZIP_VALIDATOR import required_files
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            Path(__file__).resolve().parents[1] / "litigator_cli.py",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_build(tmp_path: Path) -> None:
+    output = tmp_path / "system.json"
+    result = run_cli("build", str(output))
+    assert output.exists(), result.stdout
+    assert output.read_text().startswith("{")
+
+
+def test_validate(tmp_path: Path) -> None:
+    for file in required_files:
+        path = tmp_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x")
+    result = run_cli("validate", str(tmp_path))
+    assert "All required files" in result.stdout


### PR DESCRIPTION
## Summary
- introduce `litigator_cli` with `ingest`, `build`, and `validate` subcommands
- wire up dedicated subcommand modules and console script entry point
- cover new CLI with tests and update codex manifest

## Testing
- `black litigator_cli.py cli tests/test_litigator_cli.py codex_manifest.json`
- `flake8 litigator_cli.py cli/ingest.py cli/build.py cli/validate.py cli/__init__.py tests/test_litigator_cli.py`
- `mypy --strict --ignore-missing-imports --follow-imports=skip litigator_cli.py cli/ingest.py cli/build.py cli/validate.py tests/test_litigator_cli.py`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest integration_tests` *(fails: file or directory not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f5c5fd88322ab9209e55debac2b