### PR TITLE
[core] Add Google Drive scanner GUI

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -12,5 +12,19 @@
     "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
     "legal_function": "launch ingestion and search pipeline",
     "dependencies": ["meek_ingest_cli", "fts_cli"]
+  },
+  {
+    "module": "drive_search_gui",
+    "path": "scanner/drive_search_gui.py",
+    "hash": "c1169c33ce05b4b8c0922415dc85388b16244aef5b6be2c47f61272db1309ba3",
+    "legal_function": "search Google Drive and local drives for legal documents",
+    "dependencies": ["pydrive2", "tk"]
+  },
+  {
+    "module": "build_drive_search_exe",
+    "path": "scanner/build_drive_search_exe.py",
+    "hash": "d9d4dd0168a460375270092af2b0fb15baca1b1d8bdd8127464045132a329a3f",
+    "legal_function": "build and package Google Drive search tool",
+    "dependencies": ["PyInstaller"]
   }
 ]

--- a/gui/frontend.py
+++ b/gui/frontend.py
@@ -7,15 +7,24 @@ from warboard.ppo_warboard import build_ppo_warboard
 from warboard.custody_interference_engine import build_custody_warboard
 from scheduling.scheduler import build_schedule
 from gui.modules.entity_suppression_feed import load_events
+from scanner.drive_search_gui import launch_drive_search_gui
 
 
-def launch_dashboard():
+def launch_dashboard() -> None:
     root = tk.Tk()
-    root.title('Litigation OS')
-    root.geometry('900x600')
+    root.title("Litigation OS")
+    root.geometry("900x600")
+
+    menu = tk.Menu(root)
+    scanner_menu = tk.Menu(menu, tearoff=0)
+    scanner_menu.add_command(
+        label="Google Drive Search", command=launch_drive_search_gui
+    )
+    menu.add_cascade(label="Scanner", menu=scanner_menu)
+    root.config(menu=menu)
 
     notebook = ttk.Notebook(root)
-    notebook.pack(fill='both', expand=True)
+    notebook.pack(fill="both", expand=True)
 
     warboard_tab = ttk.Frame(notebook)
     ppo_tab = ttk.Frame(notebook)
@@ -23,59 +32,68 @@ def launch_dashboard():
     schedule_tab = ttk.Frame(notebook)
     suppression_tab = ttk.Frame(notebook)
 
-    notebook.add(warboard_tab, text='🗺️ Shady Oaks Warboard')
-    notebook.add(ppo_tab, text='🛡️ PPO Timeline')
-    notebook.add(custody_tab, text='👨‍👩‍👧 Custody Map')
-    notebook.add(schedule_tab, text='📆 Timeline Tracker')
-    notebook.add(suppression_tab, text='🧱 Entity Suppression')
+    notebook.add(warboard_tab, text="🗺️ Shady Oaks Warboard")
+    notebook.add(ppo_tab, text="🛡️ PPO Timeline")
+    notebook.add(custody_tab, text="👨‍👩‍👧 Custody Map")
+    notebook.add(schedule_tab, text="📆 Timeline Tracker")
+    notebook.add(suppression_tab, text="🧱 Entity Suppression")
 
     frame = HtmlFrame(warboard_tab)
-    frame.pack(fill='both', expand=True)
+    frame.pack(fill="both", expand=True)
     ppo_frame = HtmlFrame(ppo_tab)
-    ppo_frame.pack(fill='both', expand=True)
+    ppo_frame.pack(fill="both", expand=True)
     cust_frame = HtmlFrame(custody_tab)
-    cust_frame.pack(fill='both', expand=True)
+    cust_frame.pack(fill="both", expand=True)
     schedule_text = tk.Text(schedule_tab)
-    schedule_text.pack(fill='both', expand=True)
+    schedule_text.pack(fill="both", expand=True)
     suppression_text = tk.Text(suppression_tab)
-    suppression_text.pack(fill='both', expand=True)
+    suppression_text.pack(fill="both", expand=True)
 
-    def refresh_warboard():
+    def refresh_warboard() -> None:
         deploy_supra_warboard()
-        with open('warboard/exports/SHADY_OAKS_WARBOARD.svg') as f:
+        with open("warboard/exports/SHADY_OAKS_WARBOARD.svg") as f:
             frame.set_content(f.read())
 
-    def refresh_ppo():
+    def refresh_ppo() -> None:
         build_ppo_warboard()
-        with open('warboard/exports/PPO_WARBOARD.svg') as f:
+        with open("warboard/exports/PPO_WARBOARD.svg") as f:
             ppo_frame.set_content(f.read())
 
-    def refresh_custody():
+    def refresh_custody() -> None:
         build_custody_warboard()
-        with open('warboard/exports/CUSTODY_INTERFERENCE_MAP.svg') as f:
+        with open("warboard/exports/CUSTODY_INTERFERENCE_MAP.svg") as f:
             cust_frame.set_content(f.read())
 
-    def refresh_schedule():
+    def refresh_schedule() -> None:
         build_schedule()
-        if os.path.exists('data/timeline.json'):
+        if os.path.exists("data/timeline.json"):
             import json
-            with open('data/timeline.json') as f:
+
+            with open("data/timeline.json") as f:
                 events = json.load(f)
-            schedule_text.delete('1.0', tk.END)
+            schedule_text.delete("1.0", tk.END)
             for e in events:
                 schedule_text.insert(tk.END, f"{e['date']} - {e['description']}\n")
 
-    def refresh_suppression():
+    def refresh_suppression() -> None:
         events = load_events()
-        suppression_text.delete('1.0', tk.END)
+        suppression_text.delete("1.0", tk.END)
         for ev in events:
             suppression_text.insert(tk.END, f"{ev['entity']}: {ev['action']}\n")
 
-    ttk.Button(warboard_tab, text='Build Warboard', command=refresh_warboard).pack(pady=5)
-    ttk.Button(ppo_tab, text='Build PPO Warboard', command=refresh_ppo).pack(pady=5)
-    ttk.Button(custody_tab, text='Build Custody Map', command=refresh_custody).pack(pady=5)
-    ttk.Button(schedule_tab, text='Sync From File', command=refresh_schedule).pack(pady=5)
-    ttk.Button(suppression_tab, text='Refresh', command=refresh_suppression).pack(pady=5)
+    ttk.Button(warboard_tab, text="Build Warboard", command=refresh_warboard).pack(
+        pady=5
+    )
+    ttk.Button(ppo_tab, text="Build PPO Warboard", command=refresh_ppo).pack(pady=5)
+    ttk.Button(custody_tab, text="Build Custody Map", command=refresh_custody).pack(
+        pady=5
+    )
+    ttk.Button(schedule_tab, text="Sync From File", command=refresh_schedule).pack(
+        pady=5
+    )
+    ttk.Button(suppression_tab, text="Refresh", command=refresh_suppression).pack(
+        pady=5
+    )
 
     refresh_warboard()
     refresh_suppression()
@@ -83,5 +101,5 @@ def launch_dashboard():
     root.mainloop()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     launch_dashboard()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ python-dotenv>=1.0.1         # Load secrets/env vars securely (token, API keys)
 
 # --- GUI and Interactive Tools ---
 tkinterweb>=4.0.0            # In-app legal web search/browser for Tkinter GUI
+tk>=0.1.0                   # Tcl/Tk bindings for packaged GUI
 PySimpleGUI>=4.60.5          # Optional: advanced cross-platform GUI (modern look)
 rich>=13.7.1                 # CLI logging, progress bars, pretty errors
 

--- a/scanner/build_drive_search_exe.py
+++ b/scanner/build_drive_search_exe.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+def build() -> None:
+    subprocess.run(["pyinstaller", "drive_search_gui.spec"], check=True)
+    dist = Path("dist") / "LAWFORGE_DRIVE_SEARCH"
+    zip_path = Path("LAWFORGE_DRIVE_SEARCH.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for file in dist.rglob("*"):
+            zf.write(file, file.relative_to(dist))
+
+
+if __name__ == "__main__":
+    build()

--- a/scanner/drive_search_gui.py
+++ b/scanner/drive_search_gui.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+from pydrive2.auth import GoogleAuth
+from pydrive2.drive import GoogleDrive
+
+LEGAL_TERMS = [
+    "motion",
+    "affidavit",
+    "order",
+    "complaint",
+    "ledger",
+]
+
+keyword_entry: ttk.Entry
+filetype_var: tk.StringVar
+legal_term_var: tk.StringVar
+output_box: tk.Text
+
+drive: GoogleDrive | None = None
+
+
+def authenticate_drive() -> GoogleDrive:
+    gauth = GoogleAuth()
+    gauth.LocalWebserverAuth()
+    return GoogleDrive(gauth)
+
+
+def scan_local_drives() -> List[str]:
+    hits: List[str] = []
+    for root_drive in ("F:/", "D:/"):
+        if os.path.exists(root_drive):
+            for root_dir, _, files in os.walk(root_drive):
+                for name in files:
+                    lower = name.lower()
+                    if any(term in lower for term in LEGAL_TERMS):
+                        hits.append(os.path.join(root_dir, name))
+    return hits
+
+
+def inject_results_to_organized_data(results: List[Dict[str, str]]) -> None:
+    target = Path("F:/LAWFORGE_SERVER/organized_litigation_data.py")
+    try:
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write("\n# Auto-imported from Google Drive scan\n")
+            for result in results:
+                handle.write(f"drive_data.append({json.dumps(result)})\n")
+    except Exception as exc:
+        print(f"Failed to inject: {exc}")
+
+
+def search_drive() -> List[Dict[str, str]]:
+    assert drive is not None
+    keyword = keyword_entry.get()
+    filetype = filetype_var.get()
+    legal_term = legal_term_var.get()
+    full_query: List[str] = []
+    if keyword:
+        full_query.append(f"title contains '{keyword}'")
+    if filetype:
+        full_query.append(f"title contains '{filetype}'")
+    if legal_term:
+        full_query.append(f"title contains '{legal_term}'")
+    query = " and ".join(full_query) if full_query else "trashed=false"
+    try:
+        file_list = drive.ListFile({"q": query}).GetList()
+        results: List[Dict[str, str]] = []
+        output_box.delete("1.0", tk.END)
+        for file in file_list:
+            output_box.insert(tk.END, f"{file['title']} ({file['mimeType']})\n")
+            results.append({"title": file["title"], "mime": file["mimeType"]})
+        inject_results_to_organized_data(results)
+        local_hits = scan_local_drives()
+        for path in local_hits:
+            output_box.insert(tk.END, f"LOCAL: {path}\n")
+        return results
+    except Exception as exc:
+        messagebox.showerror("Error", str(exc))
+        return []
+
+
+def periodic_rescan(interval: int = 21600) -> None:
+    while True:
+        print("Auto-rescanning Google Drive...")
+        if drive is not None:
+            search_drive()
+        time.sleep(interval)
+
+
+def register_task_scheduler() -> None:
+    if os.name == "nt":
+        exe_path = Path.cwd() / "LAWFORGE_DRIVE_SEARCH.exe"
+        cmd = [
+            "schtasks",
+            "/Create",
+            "/SC",
+            "HOURLY",
+            "/MO",
+            "6",
+            "/TN",
+            "LawForgeDriveScan",
+            "/TR",
+            str(exe_path),
+        ]
+        try:
+            subprocess.run(cmd, check=True)
+        except Exception as exc:
+            print(f"Task schedule register failed: {exc}")
+
+
+def launch_drive_search_gui() -> None:
+    global drive, keyword_entry, filetype_var, legal_term_var, output_box
+    drive = authenticate_drive()
+    root = tk.Tk()
+    root.title("Google Drive Search Tool")
+    root.geometry("600x500")
+
+    frame = ttk.Frame(root, padding=10)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    ttk.Label(frame, text="Keyword:").grid(column=0, row=0, sticky=tk.W)
+    keyword_entry = ttk.Entry(frame, width=40)
+    keyword_entry.grid(column=1, row=0, columnspan=2, sticky=tk.W)
+
+    ttk.Label(frame, text="File Type:").grid(column=0, row=1, sticky=tk.W)
+    filetype_var = tk.StringVar()
+    filetype_dropdown = ttk.Combobox(frame, textvariable=filetype_var)
+    filetype_dropdown["values"] = (
+        ".pdf",
+        ".docx",
+        ".txt",
+        ".xlsx",
+        ".py",
+        ".json",
+        ".csv",
+        ".ps1",
+        "",
+    )
+    filetype_dropdown.grid(column=1, row=1, sticky=tk.W)
+
+    ttk.Label(frame, text="Legal Term:").grid(column=0, row=2, sticky=tk.W)
+    legal_term_var = tk.StringVar()
+    legal_term_dropdown = ttk.Combobox(frame, textvariable=legal_term_var)
+    legal_term_dropdown["values"] = (
+        "motion",
+        "affidavit",
+        "proposed order",
+        "timeline",
+        "MCR",
+        "MCL",
+        "Benchbook",
+        "exhibit",
+        "PPO",
+        "contempt",
+        "canon",
+        "violation",
+        "binder",
+        "",
+    )
+    legal_term_dropdown.grid(column=1, row=2, sticky=tk.W)
+
+    search_button = ttk.Button(frame, text="Search Drive", command=search_drive)
+    search_button.grid(column=1, row=3, pady=10, sticky=tk.W)
+
+    output_box = tk.Text(frame, height=20)
+    output_box.grid(column=0, row=4, columnspan=3, sticky="nsew")
+    frame.rowconfigure(4, weight=1)
+    frame.columnconfigure(2, weight=1)
+
+    rescan_thread = threading.Thread(target=periodic_rescan, daemon=True)
+    rescan_thread.start()
+    register_task_scheduler()
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    launch_drive_search_gui()

--- a/scanner/drive_search_gui.spec
+++ b/scanner/drive_search_gui.spec
@@ -1,0 +1,34 @@
+# drive_search_gui.spec -- PyInstaller build configuration
+block_cipher = None
+
+from PyInstaller.utils.hooks import collect_submodules
+
+a = Analysis(
+    ['drive_search_gui.py'],
+    pathex=['scanner'],
+    binaries=[],
+    datas=[('drive_auth.json', '.')],
+    hiddenimports=collect_submodules('pydrive2'),
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name='LAWFORGE_DRIVE_SEARCH',
+    debug=False,
+    strip=False,
+    upx=True,
+    console=False,
+    icon='pig_icon.ico',
+)


### PR DESCRIPTION
## Summary
- integrate Google Drive search GUI with dropdown in main dashboard
- add PyInstaller spec and build script to package scanner as EXE and ZIP
- extend requirements with tk and register modules in codex_manifest

## Testing
- `black scanner/drive_search_gui.py scanner/build_drive_search_exe.py gui/frontend.py`
- `flake8 scanner/drive_search_gui.py scanner/build_drive_search_exe.py gui/frontend.py`
- `mypy --strict --ignore-missing-imports --follow-imports=skip scanner/drive_search_gui.py scanner/build_drive_search_exe.py gui/frontend.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6b06a7888322b5fcee19ed6e2984