### PR TITLE
[core] Add DOCX template constants for chief judge pack

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -1,16 +1,23 @@
 [
-  {
-    "module": "benchbook_loader",
-    "path": "modules/benchbook_loader.py",
-    "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
-    "legal_function": "extract text from Michigan benchbook PDFs",
-    "dependencies": ["PyPDF2"]
-  },
-  {
-    "module": "meek_pipeline_launcher",
-    "path": "scripts/meek_pipeline_launcher.py",
-    "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
-    "legal_function": "launch ingestion and search pipeline",
-    "dependencies": ["meek_ingest_cli", "fts_cli"]
-  }
+    {
+        "module": "benchbook_loader",
+        "path": "modules/benchbook_loader.py",
+        "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
+        "legal_function": "extract text from Michigan benchbook PDFs",
+        "dependencies": ["PyPDF2"],
+    },
+    {
+        "module": "meek_pipeline_launcher",
+        "path": "scripts/meek_pipeline_launcher.py",
+        "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
+        "legal_function": "launch ingestion and search pipeline",
+        "dependencies": ["meek_ingest_cli", "fts_cli"],
+    },
+    {
+        "module": "chief_judge_pack",
+        "path": "scripts/chief_judge_pack.py",
+        "hash": "78aa50045291c9216cc82b0522e9ef2ba5957d949d45d9819ae1eea98c6d3148",
+        "legal_function": "generate DOCX for chief judge packet",
+        "dependencies": [],
+    },
 ]

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -16,7 +16,7 @@
     {
         "module": "chief_judge_pack",
         "path": "scripts/chief_judge_pack.py",
-        "hash": "78aa50045291c9216cc82b0522e9ef2ba5957d949d45d9819ae1eea98c6d3148",
+        "hash": "8584f21061cf18b3ec7e6886ab49d026b148cfadf5a59af2440aa0534bfd62b6",
         "legal_function": "generate DOCX for chief judge packet",
         "dependencies": [],
     },

--- a/scripts/chief_judge_pack.py
+++ b/scripts/chief_judge_pack.py
@@ -1,0 +1,95 @@
+"""Utility functions for building DOCX files for the chief judge packet.
+
+This module avoids duplicating raw WordprocessingML strings by storing
+common fragments as templates.  The templates are formatted with the
+desired text and zipped into a minimal DOCX package.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Final
+import zipfile
+from xml.sax.saxutils import escape
+
+
+# Module level constants used to assemble the DOCX structure.  These are
+# defined once so edits to the underlying XML are straightforward.
+DOCUMENT_TEMPLATE: Final[str] = (
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>{text}</w:t></w:r></w:p>
+  </w:body>
+</w:document>
+"""
+)
+
+CONTENT_TYPES_XML: Final[str] = (
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml"
+            ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>
+"""
+)
+
+RELS_XML: Final[str] = (
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+                Target="word/document.xml"/>
+</Relationships>
+"""
+)
+
+
+def create_docx_from_text(text: str, output_path: Path) -> Path:
+    """Create a minimal DOCX containing *text* and write it to *output_path*.
+
+    Parameters
+    ----------
+    text:
+        Text to embed in the resulting document.
+    output_path:
+        Location where the DOCX will be written.
+
+    Returns
+    -------
+    Path
+        The path to the generated DOCX file.
+    """
+
+    document_xml = DOCUMENT_TEMPLATE.format(text=escape(text))
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        word_dir = tmpdir_path / "word"
+        rels_dir = tmpdir_path / "_rels"
+        word_dir.mkdir()
+        rels_dir.mkdir()
+
+        (word_dir / "document.xml").write_text(document_xml, encoding="utf-8")
+        (tmpdir_path / "[Content_Types].xml").write_text(
+            CONTENT_TYPES_XML, encoding="utf-8"
+        )
+        (rels_dir / ".rels").write_text(RELS_XML, encoding="utf-8")
+
+        with zipfile.ZipFile(output_path, "w") as docx:
+            docx.write(tmpdir_path / "[Content_Types].xml", "[Content_Types].xml")
+            docx.write(rels_dir / ".rels", "_rels/.rels")
+            docx.write(word_dir / "document.xml", "word/document.xml")
+
+    return output_path
+
+
+__all__ = [
+    "create_docx_from_text",
+    "DOCUMENT_TEMPLATE",
+    "CONTENT_TYPES_XML",
+    "RELS_XML",
+]

--- a/tests/chief_judge_pack_test.py
+++ b/tests/chief_judge_pack_test.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import zipfile
+
+from scripts.chief_judge_pack import create_docx_from_text
+
+
+def test_create_docx_from_text(tmp_path: Path) -> None:
+    output = tmp_path / "sample.docx"
+    create_docx_from_text("sample text", output)
+    assert output.exists(), "DOCX file was not created"
+
+    with zipfile.ZipFile(output) as zf:
+        with zf.open("word/document.xml") as docx_file:
+            content = docx_file.read().decode("utf-8")
+
+    assert "sample text" in content


### PR DESCRIPTION
## Summary
- add reusable WordprocessingML templates for DOCX generation
- generate DOCX files from text using shared constants
- test docx builder and track module hash in manifest

## Testing
- `black scripts/chief_judge_pack.py tests/chief_judge_pack_test.py`
- `mypy --strict scripts/chief_judge_pack.py tests/chief_judge_pack_test.py`
- `flake8 scripts/chief_judge_pack.py tests/chief_judge_pack_test.py`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest integration_tests` *(fails: no such directory)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d74373648322a4908af17a5be154