### PR TITLE
[core] Verify FOIA docx hashes and handle unwritable output

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -12,5 +12,19 @@
     "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
     "legal_function": "launch ingestion and search pipeline",
     "dependencies": ["meek_ingest_cli", "fts_cli"]
+  },
+  {
+    "module": "foia_autopacker",
+    "path": "foia/autopacker.py",
+    "hash": "6b847f6dfa35be2db3b05f59f40259977c1dacb7fc260f2df6d089f368bda643",
+    "legal_function": "generate FOIA request DOCX files and ZIP package",
+    "dependencies": ["python-docx", "zipfile"]
+  },
+  {
+    "module": "foia_package",
+    "path": "foia/__init__.py",
+    "hash": "cfdbe5f7122d955d73f2ded9e384a23e7750eed11db1ffe33201b5e1a5fdbe2a",
+    "legal_function": "expose FOIA autopacker entry point",
+    "dependencies": []
   }
 ]

--- a/foia/__init__.py
+++ b/foia/__init__.py
@@ -1,0 +1,3 @@
+from .autopacker import build_requests
+
+__all__ = ["build_requests"]

--- a/foia/autopacker.py
+++ b/foia/autopacker.py
@@ -1,54 +1,88 @@
 import os
 import json
 import zipfile
+import hashlib
+import re
+from typing import Dict, List, TypedDict
 from docx import Document
 
-BASE_DIR = os.getenv('LEGAL_RESULTS_DIR', os.path.join('F:/', 'LegalResults'))
-OUTPUT_DIR = os.path.join(BASE_DIR, 'FOIA')
-LOG_PATH = os.path.join(OUTPUT_DIR, 'foia_request_log.json')
+BASE_DIR = os.getenv("LEGAL_RESULTS_DIR", os.path.join("F:/", "LegalResults"))
+OUTPUT_DIR = os.path.join(BASE_DIR, "FOIA")
+LOG_PATH = os.path.join(OUTPUT_DIR, "foia_request_log.json")
 
-REQUESTS = {
-    'EGLE': {
-        'filename': 'EGLE_request.docx',
-        'body': [
-            'Subject: Sewer leak reports for 1977 Whitehall Rd (Feb–June 2025).',
-            'Please provide all records of inspections, violation notices, and communications with the park owners.'
-        ]
+EXPECTED_HASHES: Dict[str, str] = {
+    "EGLE_request.docx": "69c71f96efede98c419a4d45465af2cb16518ac6522b7c89904c0f99b52edd2a",
+    "County_Clerk_request.docx": "43aae47f5fdc2b6eab8691f1da050ee5fb643aa5f80f496d999c1cbaca84ab8e",
+    "Sheriff_request.docx": "d7b5edebbec9624854f6ee57d84b7f8ef758fbce71018e62649f0b3d71c1abd3",
+}
+
+
+class RequestInfo(TypedDict):
+    filename: str
+    body: List[str]
+
+
+REQUESTS: Dict[str, RequestInfo] = {
+    "EGLE": {
+        "filename": "EGLE_request.docx",
+        "body": [
+            "Subject: Sewer leak reports for 1977 Whitehall Rd (Feb–June 2025).",
+            "Please provide all records of inspections, violation notices, and communications with the park owners.",
+        ],
     },
-    'County_Clerk': {
-        'filename': 'County_Clerk_request.docx',
-        'body': [
-            'Subject: Policies on counterclaims in summary proceedings.',
-            'Please provide any rejection notices or memos related to filings labelled "moot" since May 2025.'
-        ]
+    "County_Clerk": {
+        "filename": "County_Clerk_request.docx",
+        "body": [
+            "Subject: Policies on counterclaims in summary proceedings.",
+            'Please provide any rejection notices or memos related to filings labelled "moot" since May 2025.',
+        ],
     },
-    'Sheriff': {
-        'filename': 'Sheriff_request.docx',
-        'body': [
-            'Subject: Execution of eviction writ for Lot 17, 1977 Whitehall Rd.',
-            'Request any logs or bodycam footage documenting the writ execution.'
-        ]
+    "Sheriff": {
+        "filename": "Sheriff_request.docx",
+        "body": [
+            "Subject: Execution of eviction writ for Lot 17, 1977 Whitehall Rd.",
+            "Request any logs or bodycam footage documenting the writ execution.",
+        ],
     },
 }
 
-def build_requests():
+
+def _docx_sha256(path: str) -> str:
+    with zipfile.ZipFile(path, "r") as z:
+        xml = z.read("word/document.xml")
+    xml = re.sub(rb'w:rsid[^\"]*="[^"]*"', b"", xml)
+    return hashlib.sha256(xml).hexdigest()
+
+
+def build_requests() -> None:
     os.makedirs(OUTPUT_DIR, exist_ok=True)
-    log = []
+    log: List[Dict[str, str]] = []
+    hashes: Dict[str, str] = {}
     for key, info in REQUESTS.items():
         doc = Document()
-        doc.add_heading(f'FOIA Request – {key}', 0)
-        for para in info['body']:
+        doc.add_heading(f"FOIA Request – {key}", 0)
+        for para in info["body"]:
             doc.add_paragraph(para)
-        out_path = os.path.join(OUTPUT_DIR, info['filename'])
+        out_path = os.path.join(OUTPUT_DIR, info["filename"])
         doc.save(out_path)
-        log.append({'agency': key, 'file': info['filename']})
-    with open(LOG_PATH, 'w') as f:
+        file_hash = _docx_sha256(out_path)
+        hashes[info["filename"]] = file_hash
+        log.append({"agency": key, "file": info["filename"], "hash": file_hash})
+    with open(LOG_PATH, "w") as f:
         json.dump(log, f, indent=2)
-    zip_path = os.path.join(OUTPUT_DIR, 'FOIA_PACKET_SHADY_OAKS_2025.zip')
-    with zipfile.ZipFile(zip_path, 'w') as z:
+    zip_path = os.path.join(OUTPUT_DIR, "FOIA_PACKET_SHADY_OAKS_2025.zip")
+    with zipfile.ZipFile(zip_path, "w") as z:
         for item in log:
-            z.write(os.path.join(OUTPUT_DIR, item['file']), item['file'])
-    print(f'FOIA packet created at {zip_path}')
+            z.write(os.path.join(OUTPUT_DIR, item["file"]), item["file"])
+    with zipfile.ZipFile(zip_path, "r") as z:
+        missing = [name for name in EXPECTED_HASHES if name not in z.namelist()]
+        if missing:
+            raise ValueError(f"Missing files in zip: {', '.join(missing)}")
+    for filename, expected in EXPECTED_HASHES.items():
+        if hashes.get(filename) != expected:
+            raise ValueError(f"Hash mismatch for {filename}")
+    print(f"FOIA packet created at {zip_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     build_requests()

--- a/tests/test_autopacker.py
+++ b/tests/test_autopacker.py
@@ -1,0 +1,33 @@
+import os
+import importlib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def test_build_requests_creates_zip_and_hashes(tmp_path: Path) -> None:
+    os.environ["LEGAL_RESULTS_DIR"] = str(tmp_path)
+    autopacker = importlib.reload(importlib.import_module("foia.autopacker"))
+    autopacker.build_requests()
+    output_dir = Path(tmp_path) / "FOIA"
+    zip_path = output_dir / "FOIA_PACKET_SHADY_OAKS_2025.zip"
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        assert set(zf.namelist()) == set(autopacker.EXPECTED_HASHES.keys())
+    for name, expected in autopacker.EXPECTED_HASHES.items():
+        file_path = output_dir / name
+        assert autopacker._docx_sha256(str(file_path)) == expected
+
+
+def test_build_requests_unwritable_output_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    os.environ["LEGAL_RESULTS_DIR"] = str(tmp_path)
+    autopacker = importlib.reload(importlib.import_module("foia.autopacker"))
+
+    def raise_perm(*args: object, **kwargs: object) -> None:
+        raise PermissionError("cannot create directory")
+
+    monkeypatch.setattr(autopacker.os, "makedirs", raise_perm)
+    with pytest.raises(PermissionError):
+        autopacker.build_requests()


### PR DESCRIPTION
## Summary
- add SHA-256 hash verification for FOIA request DOCX files and ensure expected files are present in the generated ZIP
- record `foia.autopacker` in codex manifest and expose its entry point through the `foia` package
- test FOIA autopacker for ZIP contents, hash matching, and unwritable output directories

## Testing
- `black foia/__init__.py foia/autopacker.py tests/test_autopacker.py`
- `flake8 foia/__init__.py foia/autopacker.py tests/test_autopacker.py`
- `mypy --strict foia/__init__.py foia/autopacker.py tests/test_autopacker.py`
- `pytest tests/test_autopacker.py`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest integration_tests` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d748a8348322a4180067cea41bf2