### PR TITLE
[hotfix] Remove LEGAL_RESULTS_DIR after autopacker tests

### DIFF
--- a/tests/test_autopacker.py
+++ b/tests/test_autopacker.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+from pytest import MonkeyPatch
+
+
+def load_autopacker(monkeypatch: MonkeyPatch) -> ModuleType:
+    dummy_docx = types.SimpleNamespace(Document=object)
+    monkeypatch.setitem(sys.modules, "docx", dummy_docx)
+    monkeypatch.delitem(sys.modules, "foia.autopacker", raising=False)
+    return importlib.import_module("foia.autopacker")
+
+
+def test_custom_base_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LEGAL_RESULTS_DIR", str(tmp_path))
+    autopacker = load_autopacker(monkeypatch)
+    assert autopacker.BASE_DIR == str(tmp_path)
+    monkeypatch.delenv("LEGAL_RESULTS_DIR", raising=False)
+
+
+def test_default_base_dir(monkeypatch: MonkeyPatch) -> None:
+    autopacker = load_autopacker(monkeypatch)
+    assert autopacker.BASE_DIR == os.path.join("F:/", "LegalResults")
+    monkeypatch.delenv("LEGAL_RESULTS_DIR", raising=False)


### PR DESCRIPTION
## Summary
- add autopacker tests that clean up LEGAL_RESULTS_DIR to avoid cross-test contamination

## Testing
- `python -m black tests/test_autopacker.py`
- `python -m mypy --strict tests/test_autopacker.py`
- `python -m flake8 tests/test_autopacker.py`
- `python codex_selftest.py` (fails: file not found)
- `pytest integration_tests/` (fails: directory not found)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1e566a7f08322ae7faddd5224f6e8