### PR TITLE
Add run_all orchestration script

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -4,13 +4,30 @@
     "path": "modules/benchbook_loader.py",
     "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
     "legal_function": "extract text from Michigan benchbook PDFs",
-    "dependencies": ["PyPDF2"]
+    "dependencies": [
+      "PyPDF2"
+    ]
   },
   {
     "module": "meek_pipeline_launcher",
     "path": "scripts/meek_pipeline_launcher.py",
     "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",
     "legal_function": "launch ingestion and search pipeline",
-    "dependencies": ["meek_ingest_cli", "fts_cli"]
+    "dependencies": [
+      "fts_cli",
+      "meek_ingest_cli"
+    ]
+  },
+  {
+    "module": "run_all",
+    "path": "scripts/run_all.py",
+    "hash": "838b42d23f71cef4feb4f48c5e2817a3b190600aa66886146ce786f9662f947a",
+    "legal_function": "run build, brain update, apply patches, and archive output",
+    "dependencies": [
+      "build_system",
+      "codex_brain",
+      "codex_patch_manager",
+      "shutil"
+    ]
   }
 ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,13 @@
-# Documentation\n\nProject documentation lives here.
+# Documentation
+
+Project documentation lives here.
+
+## Run All
+
+Execute the complete build and patch sequence:
+
+```bash
+python -m scripts.run_all
+```
+
+The command runs `build_system.run()`, `codex_brain.main()`, and `codex_patch_manager.apply()` before creating the `output/archive.zip` file.

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -1,0 +1,17 @@
+import shutil
+
+from build_system import run as build_run
+from codex_brain import main as brain_main
+from codex_patch_manager import apply as patch_apply
+
+
+def main() -> None:
+    """Run the build, brain update, and patch application sequence."""
+    build_run()
+    brain_main()
+    patch_apply()
+    shutil.make_archive("output/archive", "zip", "output")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_all.py` to sequentially run build, brain update, patch apply, and archive output
- document `run_all` usage in `docs/README.md`
- register `run_all` in `codex_manifest.json` and alphabetize dependent packages

## Testing
- `python -m black scripts/run_all.py`
- `python -m flake8 scripts/run_all.py`
- `python -m mypy --strict scripts/run_all.py --follow-imports=skip`
- `python codex_selftest.py` *(fails: file not found)*
- `python -m pytest integration_tests` *(fails: directory not found)*
- `python -m pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f9aa5cdc8322afc8cbcf77725dfa