### PR TITLE
Align Codex triggers and manifest generation

### DIFF
--- a/.codex_config.yaml
+++ b/.codex_config.yaml
@@ -9,10 +9,13 @@ trigger_branches:
   - core
   - engine
   - matrix
+  - protocol
+  - epoch
   - echelon
   - patch
   - hotfix
-commit_message_format: '^[\\[(]?(core|hotfix|docs|merge|patch|engine|matrix|echelon)[\\])? .+'
+  - merge
+commit_message_format: '^\[(core|hotfix|docs|merge)\] .+'
 banned_keywords:
   - TODO
   - WIP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           done <<< "$diff"
 
           branch_name="${GITHUB_REF##*/}"
-          for key in core engine matrix patch hotfix echelon; do
+          for key in core engine matrix protocol epoch echelon hotfix patch merge; do
             if [[ "$branch_name" == *"$key"* ]]; then
               run_tests=true
               break

--- a/codex_brain.py
+++ b/codex_brain.py
@@ -14,11 +14,19 @@ def hash_file(path: Path) -> str:
 
 
 def update_manifest():
-    manifest = []
+    manifest: list[dict] = []
     for p in Path(".").rglob("*.py"):
-        if p.parts[0].startswith("."):  # skip hidden dirs
+        if p.parts[0].startswith("."):
             continue
-        manifest.append({"module": p.stem, "path": str(p), "hash": hash_file(p)})
+        manifest.append(
+            {
+                "module": p.stem,
+                "path": str(p),
+                "hash": hash_file(p),
+                "legal_function": "",
+                "dependencies": [],
+            }
+        )
     Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
 
 

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -7,6 +7,20 @@
     "dependencies": ["PyPDF2"]
   },
   {
+    "module": "codex_guardian",
+    "path": "modules/codex_guardian.py",
+    "hash": "ed7d4a3d851d8e112cb98601ae228e5a00a1778d0e48f9639778e3137fa519f4",
+    "legal_function": "enforce branch and commit policy",
+    "dependencies": []
+  },
+  {
+    "module": "codex_brain",
+    "path": "codex_brain.py",
+    "hash": "d5526d6915b4bbc5809ad773eb184d7611bbe20f376acf4291ba9a7054ade610",
+    "legal_function": "update manifest and run diagnostics",
+    "dependencies": []
+  },
+  {
     "module": "meek_pipeline_launcher",
     "path": "scripts/meek_pipeline_launcher.py",
     "hash": "44c2d8693f71df0a1de0049e5d6900116c6ba3cb3fcfd544376b0323c07e642f",

--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -30,8 +30,8 @@
   {
     "module": "graph_preview",
     "path": "scripts/graph_preview.py",
-    "hash": "ee95d6ebcc077fe2d00a41dd30ab2ac3ce76261aac025ceb486e7343b55e79f4",
-    "legal_function": "generate interactive D3 graph preview",
-    "dependencies": ["d3"]
+    "hash": "ab1a670e380e05158f96683f708ce3e16378bf34f1386fadc8c096003b61d562",
+    "legal_function": "generate interactive D3 graph preview and build SQLite snapshot",
+    "dependencies": ["d3", "sqlite3"]
   }
 ]

--- a/modules/codex_guardian.py
+++ b/modules/codex_guardian.py
@@ -34,7 +34,7 @@ def load_manifest() -> list[dict]:
 def verify_commit_message(msg: str) -> None:
     if any(k in msg for k in BANNED_KEYWORDS):
         raise ValueError("Commit message contains banned keyword")
-    if not re.match(r"^\[(core|hotfix|docs|merge|patch|engine|matrix|echelon)\] ", msg):
+    if not re.match(r"^\[(core|hotfix|docs|merge)\] ", msg):
         raise ValueError("Commit message format invalid")
 
 
@@ -48,6 +48,7 @@ def verify_branch_name(branch: str) -> bool:
         "protocol",
         "epoch",
         "echelon",
+        "patch",
         "hotfix",
         "merge",
     ]

--- a/tests/graph_preview_test.py
+++ b/tests/graph_preview_test.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import tempfile
 import importlib
 from pathlib import Path
@@ -27,3 +28,27 @@ def test_graph_preview_generates_html() -> None:
         gp.write_html(nodes, edges)
         files = list((outdir / "graph").glob("preview_*.html"))
         assert files
+
+
+def test_graph_preview_builds_db() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outdir = Path(tmpdir)
+        graph_dir = outdir / "graph"
+        graph_dir.mkdir(parents=True, exist_ok=True)
+        create_csv(
+            graph_dir / "nodes_test.csv", "id:ID,label:string", ["1,Document", "2,Name"]
+        )
+        create_csv(
+            graph_dir / "edges_test.csv", ":START_ID,:END_ID,:TYPE", ["1,2,LINK"]
+        )
+        os.environ["OUTDIR"] = str(outdir)
+        gp = importlib.reload(importlib.import_module("scripts.graph_preview"))
+        nodes, edges = gp.load_graph()
+        db_path = gp.build_db(nodes, edges, outdir / "graph.db")
+        assert db_path.exists()
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM nodes")
+            assert cur.fetchone()[0] == len(nodes)
+            cur.execute("SELECT COUNT(*) FROM edges")
+            assert cur.fetchone()[0] == len(edges)


### PR DESCRIPTION
## Summary
- extend Codex branch triggers for build workflow and config
- tighten commit message guardian and manifest generation
- record codex_brain and codex_guardian hashes in codex_manifest

## Testing
- `black --check codex_brain.py modules/codex_guardian.py`
- `mypy --strict codex_brain.py modules/codex_guardian.py` (fails: Missing type parameters for generic type "dict")
- `flake8 codex_brain.py modules/codex_guardian.py`
- `if [ -f codex_selftest.py ]; then python codex_selftest.py; else echo 'codex_selftest.py not found'; fi`
- `if [ -d integration_tests ]; then pytest integration_tests; else echo 'integration_tests directory not found'; fi`
- `pytest`
- `python codex_brain.py` (fails: Branch name must start with 'codex/')

------
https://chatgpt.com/codex/tasks/task_e_68b4e0f27cc08322bdc4059fdcd9298f