### PR TITLE
[patch] Enforce bracketed commit message format

### DIFF
--- a/.codex_config.yaml
+++ b/.codex_config.yaml
@@ -12,7 +12,7 @@ trigger_branches:
   - echelon
   - patch
   - hotfix
-commit_message_format: '^[\\[(]?(core|hotfix|docs|merge|patch|engine|matrix|echelon)[\\])? .+'
+commit_message_format: '^\[(core|hotfix|docs|merge|patch|engine|matrix|echelon)\] .+'
 banned_keywords:
   - TODO
   - WIP


### PR DESCRIPTION
## Summary
- require commit messages to use square-bracketed prefixes

## Testing
- `python - <<'PY'
import yaml, sys
with open('.codex_config.yaml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4e0f27cc08322bdc4059fdcd9298f