### PR TITLE
[core] Add codex config and inline guardian

### DIFF
--- a/.codex_config.yaml
+++ b/.codex_config.yaml
@@ -1,29 +1,5 @@
-# MBP Codex Supreme Configuration
-branch_prefix: 'codex/'
-run_tests_on_changes:
-  - '**/*.py'
-  - '**/*.js'
-  - '**/*.ts'
-  - '**/*.json'
-trigger_branches:
-  - core
-  - engine
-  - matrix
-  - echelon
-  - patch
-  - hotfix
-commit_message_format: '^\[(core|hotfix|docs|merge|patch|engine|matrix|echelon)\] .+'
-banned_keywords:
-  - TODO
-  - WIP
-  - temp_var
-  - placeholder
-manifest: 'codex_manifest.json'
-required_folders:
-  - core
-  - modules
-  - gui
-  - cli
-  - config
-  - docs
-  - tests
+{
+  "branch_prefix": "codex/",
+  "commit_types": ["core", "hotfix", "docs", "merge", "patch", "engine", "matrix", "echelon"],
+  "banned_keywords": ["TODO", "WIP", "temp_var", "placeholder"]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Verify Codex Config
+        run: test -f .codex_config.yaml
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/codex_brain.py
+++ b/codex_brain.py
@@ -1,11 +1,13 @@
 import hashlib
 import json
+import subprocess
 from pathlib import Path
+from typing import Any, Dict, cast
 
-from modules.codex_guardian import run_guardian
 from modules.codex_supreme import self_diagnostic
 
 MANIFEST = "codex_manifest.json"
+CONFIG_PATH = Path(".codex_config.yaml")
 
 
 def hash_file(path: Path) -> str:
@@ -13,17 +15,42 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def update_manifest():
+def load_config() -> Dict[str, Any]:
+    return cast(Dict[str, Any], json.loads(CONFIG_PATH.read_text()))
+
+
+def enforce_guardian(cfg: Dict[str, Any]) -> None:
+    branch = (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .decode()
+        .strip()
+    )
+    message = (
+        subprocess.check_output(["git", "log", "-1", "--pretty=%B"])
+        .decode()
+        .strip()
+        .splitlines()[0]
+    )
+    if not branch.startswith(cfg["branch_prefix"]):
+        raise ValueError("branch name must start with codex/")
+    if any(keyword in message for keyword in cfg["banned_keywords"]):
+        raise ValueError("commit message contains banned keyword")
+    if not any(message.startswith(f"[{kind}] ") for kind in cfg["commit_types"]):
+        raise ValueError("commit message format invalid")
+
+
+def update_manifest() -> None:
     manifest = []
     for p in Path(".").rglob("*.py"):
-        if p.parts[0].startswith("."):  # skip hidden dirs
+        if p.parts[0].startswith("."):
             continue
         manifest.append({"module": p.stem, "path": str(p), "hash": hash_file(p)})
     Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
 
 
 def main() -> None:
-    run_guardian()
+    cfg = load_config()
+    enforce_guardian(cfg)
     update_manifest()
     self_diagnostic()
     print("codex manifest updated")


### PR DESCRIPTION
## Summary
- embed commit and branch enforcement directly in `codex_brain.py`
- store enforcement rules in `.codex_config.yaml`
- verify codex config presence during CI builds

## Testing
- `black codex_brain.py`
- `flake8 codex_brain.py`
- `mypy --strict --ignore-missing-imports --follow-imports=skip codex_brain.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e67e1ebc8322aa89f85b253855df