### PR TITLE
[core] Add hash verification and sandbox to patch manager

### DIFF
--- a/codex_patch_manager.py
+++ b/codex_patch_manager.py
@@ -1,65 +1,117 @@
-import os, importlib.util, json, shutil, logging, datetime
+import os
+import json
+import shutil
+import logging
+import datetime
+import hashlib
+import builtins
+from typing import Any, List, Optional, Sequence
 
-PATCH_DIR = "patches/"
-MANIFEST_FILE = "patch_manifest.json"
-ERROR_LOG = "logs/codex_errors.log"
-PATCH_HISTORY = "patch_history.json"
-logging.basicConfig(filename=ERROR_LOG, level=logging.ERROR)
+PATCH_DIR: str = "patches/"
+MANIFEST_FILE: str = "patch_manifest.json"
+ERROR_LOG: str = "logs/codex_errors.log"
+PATCH_HISTORY: str = "patch_history.json"
+RESTRICTED_MODULES = {"os", "sys", "subprocess"}
+
+os.makedirs(os.path.dirname(ERROR_LOG), exist_ok=True)
+logging.basicConfig(filename=ERROR_LOG, level=logging.INFO)
 
 
-def backup_file(filepath):
+def backup_file(filepath: str) -> str:
     bak_name = f"{filepath}.{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}.bak"
     shutil.copy2(filepath, bak_name)
     return bak_name
 
 
-def apply_patch(patch_path, target_file):
+def verify_patch_hash(patch_path: str, expected_hash: str) -> bool:
+    hasher = hashlib.sha256()
+    with open(patch_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest() == expected_hash
+
+
+def apply_patch(
+    patch_path: str, target_file: str, allowed_modules: Optional[List[str]] = None
+) -> None:
     bak = backup_file(target_file)
+    allowed = set(allowed_modules or [])
+
+    def restricted_import(
+        name: str,
+        globals: Optional[dict[str, Any]] = None,
+        locals: Optional[dict[str, Any]] = None,
+        fromlist: Sequence[str] = (),
+        level: int = 0,
+    ) -> Any:
+        if name in RESTRICTED_MODULES and name not in allowed:
+            raise ImportError(f"Import of {name} is restricted")
+        return __import__(name, globals, locals, fromlist, level)
+
+    safe_builtins = {k: getattr(builtins, k) for k in dir(builtins)}
+    safe_builtins["__import__"] = restricted_import
+
     try:
-        spec = importlib.util.spec_from_file_location("patch_module", patch_path)
-        patch_module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(patch_module)
+        with open(patch_path, "r", encoding="utf-8") as f:
+            code = f.read()
+        exec(code, {"__builtins__": safe_builtins})
         log_patch(patch_path, target_file, bak, "success")
-    except Exception as e:
-        logging.error(f"Patch failed for {patch_path} on {target_file}: {e}")
+        logging.info("Patch applied: %s -> %s", patch_path, target_file)
+    except Exception:
+        logging.exception("Patch failed for %s on %s", patch_path, target_file)
         shutil.copy2(bak, target_file)
         log_patch(patch_path, target_file, bak, "rollback")
         print(f"Rolled back patch {patch_path}")
 
 
-def log_patch(patch, target, backup, status):
+def log_patch(patch: str, target: str, backup: str, status: str) -> None:
     entry = {
         "patch": patch,
         "target": target,
         "backup": backup,
         "status": status,
-        "timestamp": datetime.datetime.now().isoformat()
+        "timestamp": datetime.datetime.now().isoformat(),
     }
     if os.path.exists(PATCH_HISTORY):
-        with open(PATCH_HISTORY, 'r') as f:
+        with open(PATCH_HISTORY, "r", encoding="utf-8") as f:
             history = json.load(f)
     else:
         history = []
     history.append(entry)
-    with open(PATCH_HISTORY, 'w') as f:
+    with open(PATCH_HISTORY, "w", encoding="utf-8") as f:
         json.dump(history, f, indent=2)
 
 
-if not os.path.exists(PATCH_DIR):
-    print("⚠️ No patches found.")
-    exit(0)
+def main() -> None:
+    if not os.path.exists(PATCH_DIR):
+        print("⚠️ No patches found.")
+        return
 
-with open(MANIFEST_FILE) as f:
-    manifest = json.load(f)
+    try:
+        with open(MANIFEST_FILE, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except FileNotFoundError:
+        logging.error("Manifest file not found.")
+        return
 
-for patch_file in os.listdir(PATCH_DIR):
-    if patch_file.endswith(".py"):
-        patch_path = os.path.join(PATCH_DIR, patch_file)
-        target = manifest.get(patch_file, {}).get("target", None)
-        if target and os.path.exists(target):
+    for patch_file in os.listdir(PATCH_DIR):
+        if patch_file.endswith(".py"):
+            patch_path = os.path.join(PATCH_DIR, patch_file)
+            meta = manifest.get(patch_file, {})
+            target = meta.get("target")
+            expected_hash = meta.get("hash")
+            allowed = meta.get("allow", [])
+            if not target or not os.path.exists(target):
+                logging.error("No valid target for patch: %s", patch_file)
+                continue
+            if not expected_hash or not verify_patch_hash(patch_path, expected_hash):
+                logging.error("Hash mismatch for patch: %s", patch_file)
+                continue
             print(f"🔧 Applying patch: {patch_file} to {target}")
-            apply_patch(patch_path, target)
-        else:
-            logging.error(f"No valid target for patch: {patch_file}")
+            apply_patch(patch_path, target, allowed)
 
-print("✅ All patches applied successfully.")
+    print("✅ All patches processed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_patch_manager.py
+++ b/tests/test_patch_manager.py
@@ -1,0 +1,45 @@
+import hashlib
+import logging
+from pathlib import Path
+
+import codex_patch_manager as cpm
+
+
+def test_verify_patch_hash(tmp_path: Path) -> None:
+    patch = tmp_path / "patch.py"
+    patch.write_text("x = 1\n", encoding="utf-8")
+    expected = hashlib.sha256(patch.read_bytes()).hexdigest()
+    assert cpm.verify_patch_hash(str(patch), expected)
+    assert not cpm.verify_patch_hash(str(patch), "0" * 64)
+
+
+def test_apply_patch_blocks_restricted_modules(tmp_path: Path) -> None:
+    cpm.PATCH_HISTORY = str(tmp_path / "history.json")
+    cpm.ERROR_LOG = str(tmp_path / "errors.log")
+    logging.basicConfig(filename=cpm.ERROR_LOG, level=logging.INFO, force=True)
+
+    target = tmp_path / "target.txt"
+    target.write_text("orig", encoding="utf-8")
+    patch = tmp_path / "patch.py"
+    patch.write_text(
+        "import os\nopen(r'{}','w').write('patched')".format(target),
+        encoding="utf-8",
+    )
+    cpm.apply_patch(str(patch), str(target))
+    assert target.read_text(encoding="utf-8") == "orig"
+
+
+def test_apply_patch_success(tmp_path: Path) -> None:
+    cpm.PATCH_HISTORY = str(tmp_path / "history.json")
+    cpm.ERROR_LOG = str(tmp_path / "errors.log")
+    logging.basicConfig(filename=cpm.ERROR_LOG, level=logging.INFO, force=True)
+
+    target = tmp_path / "target.txt"
+    target.write_text("orig", encoding="utf-8")
+    patch = tmp_path / "patch.py"
+    patch.write_text(
+        "open(r'{}','w').write('patched')".format(target),
+        encoding="utf-8",
+    )
+    cpm.apply_patch(str(patch), str(target))
+    assert target.read_text(encoding="utf-8") == "patched"


### PR DESCRIPTION
## Summary
- verify patch files against sha256 hashes in manifest before applying
- sandbox patch execution to block os/sys/subprocess imports
- log patch activity and add tests for patch hashing and sandboxing

## Testing
- `black codex_patch_manager.py tests/test_patch_manager.py`
- `flake8 codex_patch_manager.py tests/test_patch_manager.py`
- `mypy --strict codex_patch_manager.py tests/test_patch_manager.py`
- `python codex_selftest.py` *(fails: file not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a3809bc83228e5b24254dbb2e49