### PR TITLE
[core] Improve benchbook loader robustness

### DIFF
--- a/codex_manifest.json
+++ b/codex_manifest.json
@@ -2,7 +2,7 @@
   {
     "module": "benchbook_loader",
     "path": "modules/benchbook_loader.py",
-    "hash": "659ea627d4c1f2b1b93118ce5f16d52e13fb23e79cbb44a6ade1b609c14ece18",
+    "hash": "e0205c8ea5704d5e9a094e83c8beeb74735277e9c468378c40f220b4c538ae67",
     "legal_function": "extract text from Michigan benchbook PDFs",
     "dependencies": ["PyPDF2"]
   },

--- a/modules/benchbook_loader.py
+++ b/modules/benchbook_loader.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Dict
 
 from PyPDF2 import PdfReader
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_benchbook_texts(directory: str) -> Dict[str, str]:
@@ -16,11 +20,26 @@ def load_benchbook_texts(directory: str) -> Dict[str, str]:
         A mapping of PDF file names to their extracted text.
     """
     dir_path = Path(directory)
+    if not dir_path.is_dir():
+        raise FileNotFoundError(f"Directory not found: {directory}")
+
     texts: Dict[str, str] = {}
     for pdf_path in dir_path.glob("*.pdf"):
-        reader = PdfReader(str(pdf_path))
+        try:
+            reader = PdfReader(str(pdf_path))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to read PDF %s: %s", pdf_path, exc)
+            continue
         content = ""
-        for page in reader.pages:
-            content += page.extract_text() or ""
+        for page_num, page in enumerate(reader.pages, start=1):
+            try:
+                content += page.extract_text() or ""
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "Failed to extract text from %s page %s: %s",
+                    pdf_path,
+                    page_num,
+                    exc,
+                )
         texts[pdf_path.name] = content
     return texts

--- a/tests/test_benchbook_loader.py
+++ b/tests/test_benchbook_loader.py
@@ -1,15 +1,40 @@
+from __future__ import annotations
+
+import logging
 from pathlib import Path
 
+import pytest
 from PyPDF2 import PdfWriter
 
 from modules.benchbook_loader import load_benchbook_texts
 
 
-def test_load_benchbook_texts(tmp_path: Path) -> None:
-    pdf_path = tmp_path / "sample.pdf"
+def _create_pdf(path: Path) -> None:
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
-    with open(pdf_path, "wb") as f:
+    with path.open("wb") as f:
         writer.write(f)
+
+
+def test_valid_pdf(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "sample.pdf"
+    _create_pdf(pdf_path)
     texts = load_benchbook_texts(str(tmp_path))
     assert pdf_path.name in texts
+
+
+def test_missing_directory() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_benchbook_texts("missing_dir")
+
+
+def test_corrupt_pdf(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    good = tmp_path / "good.pdf"
+    bad = tmp_path / "bad.pdf"
+    _create_pdf(good)
+    bad.write_bytes(b"not a pdf")
+    with caplog.at_level(logging.WARNING):
+        texts = load_benchbook_texts(str(tmp_path))
+    assert good.name in texts
+    assert bad.name not in texts
+    assert any("Failed to read PDF" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- validate benchbook directory existence
- log and skip unreadable PDFs during loading
- test valid, missing, and corrupt PDF scenarios

## Testing
- `python -m black modules/benchbook_loader.py tests/test_benchbook_loader.py`
- `python -m flake8 modules/benchbook_loader.py tests/test_benchbook_loader.py`
- `python -m mypy --strict modules/benchbook_loader.py tests/test_benchbook_loader.py`
- `pytest tests/test_benchbook_loader.py -q`
- `python codex_selftest.py` *(fails: No such file or directory)*
- `pytest integration_tests -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a3779a083229d41ede4eb06c57c