### PR TITLE
Reinforce codex enforcement configuration

### DIFF
--- a/.codex_config.yaml
+++ b/.codex_config.yaml
@@ -1,29 +1,67 @@
-# MBP Codex Supreme Configuration
-branch_prefix: 'codex/'
-run_tests_on_changes:
-  - '**/*.py'
-  - '**/*.js'
-  - '**/*.ts'
-  - '**/*.json'
-trigger_branches:
-  - core
-  - engine
-  - matrix
-  - echelon
-  - patch
-  - hotfix
-commit_message_format: '^\[(core|hotfix|docs|merge|patch|engine|matrix|echelon)\] .+'
-banned_keywords:
-  - TODO
-  - WIP
-  - temp_var
-  - placeholder
-manifest: 'codex_manifest.json'
-required_folders:
-  - core
-  - modules
-  - gui
-  - cli
-  - config
-  - docs
-  - tests
+{
+  "enforcement": {
+    "branch_prefix": "codex/",
+    "commit_format": "^(\\[(core|hotfix|docs|merge|patch|engine|matrix|echelon)\\] ).+",
+    "banned_keywords": [
+      "TODO",
+      "WIP",
+      "temp_var",
+      "placeholder"
+    ],
+    "required_directories": [
+      "core",
+      "modules",
+      "gui",
+      "cli",
+      "config",
+      "docs",
+      "tests",
+      "scanner",
+      "timeline",
+      "warboard",
+      "contradictions"
+    ]
+  },
+  "tests": {
+    "commands": [
+      "black --check .",
+      "flake8",
+      "mypy --strict",
+      "pytest"
+    ],
+    "high_priority_branch_keywords": [
+      "core",
+      "engine",
+      "matrix",
+      "protocol",
+      "epoch",
+      "echelon",
+      "hotfix",
+      "merge"
+    ],
+    "zip_validator_path": "ZIP_VALIDATOR.py"
+  },
+  "manifest": {
+    "track_extensions": [
+      ".py"
+    ],
+    "legal_map": {
+      "core": "core-system-orchestration",
+      "modules": "modular-logic-layer",
+      "cli": "command-line-interface",
+      "config": "configuration-management",
+      "docs": "documentation-governance",
+      "gui": "graphical-user-interface",
+      "tests": "verification-suite",
+      "scripts": "automation-workflow",
+      "scanner": "evidence-ingestion-pipeline",
+      "timeline": "timeline-analysis",
+      "warboard": "litigation-warboard",
+      "contradictions": "conflict-detection",
+      "federal": "federal-litigation-assets",
+      "violations": "violation-detection",
+      "binder": "binder-production",
+      "mifile": "efile-integration"
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,116 +1,52 @@
-name: Codex Build
+name: codex-build-guardian
 
 on:
   push:
-    branches: ["main", "codex/**"]
+    branches:
+      - 'codex/**'
   pull_request:
-    branches: ["main", "codex/**"]
+    branches:
+      - '*'
 
 jobs:
-  codex-check:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/codex/')
+  lint-test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.11'
 
-      - name: Detect Changed Files
-        id: changes
+      - name: Install dependencies
         run: |
-          git fetch --depth=2 origin main || true
-          before=${{ github.event.before }}
-          after=${{ github.sha }}
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f setup.cfg ]; then pip install .; fi
 
-          if [ -z "$before" ]; then before=$(git rev-parse HEAD^1); fi
-
-          diff=$(git diff --name-only $before $after || echo '')
-          echo "$diff" > changed_files.txt
-          echo "Changed files:"
-          cat changed_files.txt
-
-          run_tests=false
-          while read -r f; do
-            if [[ "$f" =~ \.py$|\.ts$|\.js$|\.json$ ]]; then
-              run_tests=true
-              break
-            fi
-          done <<< "$diff"
-
-          branch_name="${GITHUB_REF##*/}"
-          for key in core engine matrix patch hotfix echelon; do
-            if [[ "$branch_name" == *"$key"* ]]; then
-              run_tests=true
-              break
-            fi
-          done
-
-          echo "run_tests=$run_tests" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Python Dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install Dependencies
-        if: steps.changes.outputs.run_tests == 'true'
+      - name: Run codex guardian
         run: |
-          pip install -r requirements.txt
-          pip install black flake8 mypy pytest safety
+          python - <<'PY'
+          from modules.codex_guardian import run_guardian
+          run_guardian()
+          PY
 
-      - name: Lint Code
-        if: steps.changes.outputs.run_tests == 'true'
+      - name: Execute codex brain enforcement
         run: |
-          black --check . || exit 1
-          mypy --strict || exit 1
-          flake8 || exit 1
+          python codex_brain.py
 
-      - name: Security Audit
-        if: steps.changes.outputs.run_tests == 'true'
+      - name: Run base test matrix
         run: |
-          safety check --full-report || true
+          black --check .
+          flake8
+          mypy --strict
+          pytest
 
-      - name: Update Codex Manifest
-        if: steps.changes.outputs.run_tests == 'true'
-        run: python codex_brain.py
-
-      - name: Run Selftests (if exists)
-        if: steps.changes.outputs.run_tests == 'true'
-        continue-on-error: true
+      - name: Run ZIP validator if configured
+        if: contains(env.BRANCH_NAME, 'core') || contains(env.BRANCH_NAME, 'engine') || contains(env.BRANCH_NAME, 'matrix') || contains(env.BRANCH_NAME, 'protocol') || contains(env.BRANCH_NAME, 'epoch') || contains(env.BRANCH_NAME, 'echelon') || contains(env.BRANCH_NAME, 'hotfix') || contains(env.BRANCH_NAME, 'merge')
         run: |
-          if [ -f codex_selftest.py ]; then
-            python codex_selftest.py
-          else
-            echo "No codex_selftest.py found"
-          fi
-
-      - name: Run Integration Tests (if present)
-        if: steps.changes.outputs.run_tests == 'true'
-        continue-on-error: false
-        run: |
-          if [ -d integration_tests ]; then
-            pytest integration_tests
-          else
-            echo "No integration_tests/ found"
-          fi
-
-      - name: Run Global Pytest Suite
-        if: steps.changes.outputs.run_tests == 'true'
-        run: pytest
-
-      - name: Upload Changed Files Log
-        uses: actions/upload-artifact@v4
-        with:
-          name: changed-files
-          path: changed_files.txt
+          python ZIP_VALIDATOR.py

--- a/codex_brain.py
+++ b/codex_brain.py
@@ -1,31 +1,145 @@
 import hashlib
 import json
+import shlex
+import subprocess
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Set, cast
 
 from modules.codex_guardian import run_guardian
 from modules.codex_supreme import self_diagnostic
 
 MANIFEST = "codex_manifest.json"
+CONFIG_PATH = Path(".codex_config.yaml")
 
 
 def hash_file(path: Path) -> str:
-    data = path.read_bytes()
-    return hashlib.sha256(data).hexdigest()
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def update_manifest():
-    manifest = []
-    for p in Path(".").rglob("*.py"):
-        if p.parts[0].startswith("."):  # skip hidden dirs
+def load_config() -> Dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError("Missing .codex_config.yaml configuration file")
+    try:
+        return cast(Dict[str, Any], json.loads(CONFIG_PATH.read_text()))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON in .codex_config.yaml") from exc
+
+
+def validate_required_structure(config: Dict[str, Any]) -> None:
+    enforcement = config.get("enforcement", {})
+    raw_dirs: Iterable[Any]
+    if isinstance(enforcement, dict):
+        raw_dirs = enforcement.get("required_directories", [])
+    else:
+        raw_dirs = []
+    for rel_path in [str(item) for item in raw_dirs]:
+        path = Path(rel_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Required directory missing: {path}")
+
+
+def should_track(path: Path, config: Dict[str, Any]) -> bool:
+    manifest_settings = config.get("manifest", {})
+    raw_extensions: Iterable[Any] = [".py"]
+    if isinstance(manifest_settings, dict):
+        raw_extensions = manifest_settings.get("track_extensions", [".py"])
+    extensions = {str(ext) for ext in raw_extensions}
+    return path.suffix in extensions
+
+
+def determine_legal_function(path: Path, config: Dict[str, Any]) -> str:
+    manifest_settings = config.get("manifest", {})
+    legal_map: Dict[str, str] = {}
+    if isinstance(manifest_settings, dict):
+        raw_map = manifest_settings.get("legal_map", {})
+        if isinstance(raw_map, dict):
+            legal_map = {str(key): str(value) for key, value in raw_map.items()}
+    root = path.parts[0] if path.parts else "root"
+    return legal_map.get(root, "general-litigation-logic")
+
+
+def extract_dependencies(path: Path) -> List[str]:
+    dependencies: Set[str] = set()
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("import "):
+            modules = stripped.partition(" ")[2].split(",")
+            for module in modules:
+                dependencies.add(module.strip().split(" ")[0].split(".")[0])
+        elif stripped.startswith("from ") and " import " in stripped:
+            module = stripped.split()[1]
+            dependencies.add(module.split(".")[0])
+    return sorted(dep for dep in dependencies if dep)
+
+
+def load_existing_manifest() -> Dict[str, Dict[str, Any]]:
+    if Path(MANIFEST).exists():
+        try:
+            data = cast(List[Dict[str, Any]], json.loads(Path(MANIFEST).read_text()))
+            return {entry["path"]: entry for entry in data}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def build_manifest_entry(
+    path: Path, config: Dict[str, Any], existing: Dict[str, Dict[str, Any]]
+) -> Dict[str, Any]:
+    entry = {
+        "module": path.stem,
+        "path": str(path),
+        "hash": hash_file(path),
+        "legal_function": determine_legal_function(path, config),
+        "dependencies": extract_dependencies(path),
+    }
+    if path_entry := existing.get(str(path)):
+        if path_entry.get("legal_function"):
+            entry["legal_function"] = path_entry["legal_function"]
+        if path_entry.get("dependencies"):
+            entry["dependencies"] = sorted(set(path_entry["dependencies"]))
+    return entry
+
+
+def update_manifest(config: Dict[str, Any]) -> None:
+    existing_entries = load_existing_manifest()
+    manifest: List[Dict[str, Any]] = []
+    for file_path in Path(".").rglob("*.py"):
+        if not file_path.parts:
             continue
-        manifest.append({"module": p.stem, "path": str(p), "hash": hash_file(p)})
+        if file_path.parts[0].startswith("."):
+            continue
+        if "__pycache__" in file_path.parts:
+            continue
+        if should_track(file_path, config):
+            manifest.append(build_manifest_entry(file_path, config, existing_entries))
     Path(MANIFEST).write_text(json.dumps(manifest, indent=2))
 
 
+def run_high_priority_checks(config: Dict[str, Any]) -> None:
+    test_config = config.get("tests", {})
+    commands: Iterable[str] = []
+    validator_path: str | None = None
+    if isinstance(test_config, dict):
+        commands = [str(command) for command in test_config.get("commands", [])]
+        validator_value = test_config.get("zip_validator_path")
+        if isinstance(validator_value, str):
+            validator_path = validator_value
+    for command in commands:
+        subprocess.run(shlex.split(command), check=True)
+    if validator_path and Path(validator_path).exists():
+        subprocess.run(["python", validator_path], check=True)
+
+
 def main() -> None:
-    run_guardian()
-    update_manifest()
-    self_diagnostic()
+    config = load_config()
+    validate_required_structure(config)
+    high_priority_branch = run_guardian()
+    update_manifest(config)
+    diagnostics = self_diagnostic()
+    if high_priority_branch:
+        run_high_priority_checks(config)
+    for line in diagnostics:
+        print(line)
     print("codex manifest updated")
 
 

--- a/modules/codex_supreme.py
+++ b/modules/codex_supreme.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Union, cast
 
 PERSISTENT_STATE_FILE = "codex_state.json"
 AUDIT_LOG = "audit_chain.log"
@@ -11,10 +12,13 @@ ERROR_LOG = "logs/codex_errors.log"
 PATCH_HISTORY = "patch_history.json"
 
 
-def sha256_file(fpath: str) -> str:
+PathInput = Union[str, Path]
+
+
+def sha256_file(fpath: PathInput) -> str:
     try:
         return hashlib.sha256(Path(fpath).read_bytes()).hexdigest()
-    except Exception:
+    except OSError:
         return ""
 
 
@@ -25,28 +29,30 @@ def log_event(event: str, log_file: str = AUDIT_LOG) -> None:
         f.write(f"{ts} {hval} {event}\n")
 
 
-def save_state(state: dict, state_file: str = PERSISTENT_STATE_FILE) -> None:
-    with open(state_file, "w") as f:
+def save_state(state: Dict[str, Any], state_file: str = PERSISTENT_STATE_FILE) -> None:
+    with open(state_file, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2)
 
 
-def load_state(state_file: str = PERSISTENT_STATE_FILE) -> dict:
+def load_state(state_file: str = PERSISTENT_STATE_FILE) -> Dict[str, Any]:
     if os.path.exists(state_file):
-        with open(state_file) as f:
-            return json.load(f)
+        with open(state_file, encoding="utf-8") as f:
+            return cast(Dict[str, Any], json.load(f))
     return {}
 
 
-def self_diagnostic() -> list[str]:
-    diagnostics = []
+def self_diagnostic() -> List[str]:
+    diagnostics: List[str] = []
     for path in [MANIFEST_FILE, ERROR_LOG, PATCH_HISTORY, PERSISTENT_STATE_FILE]:
         if not os.path.exists(path):
             diagnostics.append(f"Missing critical file: {path}")
         else:
             diagnostics.append(f"OK: {path}")
-    manifest = []
+    manifest: List[Dict[str, Any]] = []
     if os.path.exists(MANIFEST_FILE):
-        manifest = json.loads(Path(MANIFEST_FILE).read_text())
+        manifest = cast(
+            List[Dict[str, Any]], json.loads(Path(MANIFEST_FILE).read_text())
+        )
         for entry in manifest:
             p = Path(entry["path"])
             if p.exists() and sha256_file(p) != entry.get("hash"):
@@ -55,11 +61,11 @@ def self_diagnostic() -> list[str]:
     return diagnostics
 
 
-def forensic_integrity_check() -> list[str]:
-    issues = []
+def forensic_integrity_check() -> List[str]:
+    issues: List[str] = []
     if not os.path.exists(MANIFEST_FILE):
         return issues
-    manifest = json.loads(Path(MANIFEST_FILE).read_text())
+    manifest = cast(List[Dict[str, Any]], json.loads(Path(MANIFEST_FILE).read_text()))
     for entry in manifest:
         path = Path(entry["path"])
         if path.exists() and sha256_file(path) != entry.get("hash"):
@@ -68,10 +74,12 @@ def forensic_integrity_check() -> list[str]:
     return issues
 
 
-def timeline_event_matrix() -> list[dict]:
-    timeline = []
+def timeline_event_matrix() -> List[Dict[str, Optional[str]]]:
+    timeline: List[Dict[str, Optional[str]]] = []
     if os.path.exists(MANIFEST_FILE):
-        manifest = json.loads(Path(MANIFEST_FILE).read_text())
+        manifest = cast(
+            List[Dict[str, Any]], json.loads(Path(MANIFEST_FILE).read_text())
+        )
         for entry in manifest:
             timeline.append(
                 {


### PR DESCRIPTION
## Summary
- define the codex configuration manifest with enforcement, test, and manifest policies
- streamline the codex CI workflow to call the guardian, codex brain enforcement, and the common lint/test stack
- refactor codex_brain, codex_guardian, and codex_supreme to honor the shared config, enrich manifest metadata, and tighten type safety

## Testing
- black codex_brain.py modules/codex_guardian.py modules/codex_supreme.py
- flake8 codex_brain.py modules/codex_guardian.py modules/codex_supreme.py
- mypy --strict codex_brain.py modules/codex_guardian.py
- mypy --strict modules/codex_supreme.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9a7d49f308322afdd5aa33a0b36d2