### PR TITLE
Refine mypy exclusions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = (?x)(^gui/modules/.*$|^tarball\.py$)


### PR DESCRIPTION
## Summary
- expand the repository-level mypy exclusion so the Bash-based `tarball.py` script is skipped alongside the duplicate `gui/modules` package

## Testing
- `python -m mypy --strict .` *(fails: repository contains many pre-existing typing issues, but the duplicate-module configuration error is resolved)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69001a36057483228f0fd5ba0bfcae0a)