### PR TITLE
docs: add MCP README and Makefile usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,10 @@ readme_content = """
 
 This repo enables **offline, token-free litigation automation** for the FRED PRIME system using PowerShell and a JSON-configurable engine.
 
----
-
 ## ✅ What This System Does
 
-- 🔖 Auto-labels exhibits (Exhibit A–Z)
-- 🔗 Links motions to matching exhibits
-- 🧾 Validates MCR 1.109(D)(3) signature block compliance
-- 📅 Builds parenting time violation matrix from AppClose logs (Exhibit Y)
-- 🛑 Tracks false police reports and PPO misuse (Exhibit S)
-- ⚖️ Logs judicial irregularities (Exhibit U)
+## 🗂 Structure
 
 ---
 
-## 🗂 Structure
+Developer note: MCP / CONTEXT7 key setup information and a Makefile helper are documented in `docs/README_MCP.md` and `docs/MAKEFILE_USAGE.md`.

--- a/README_MCP.md
+++ b/README_MCP.md
@@ -1,0 +1,47 @@
+# MCP / CONTEXT7 key setup
+
+This document explains how the MCP entry in `mcp.json` expects the `CONTEXT7_API_KEY` to be provided, and documents the provided `tools/context7-setup` Makefile helper.
+
+## How the MCP reads the key
+
+- The MCP configuration prefers the environment variable `CONTEXT7_API_KEY`.
+- It will not prompt interactively; the MCP reads `${env:CONTEXT7_API_KEY}`.
+
+## Local development options
+
+- Create or update `tools/.mcp_env` and add `CONTEXT7_API_KEY=...`, then load it into your shell:
+
+```bash
+set -a; source tools/.mcp_env; set +a
+```
+
+- Or use the helper Makefile target (from repo root):
+
+```bash
+# make the helper executable and run it
+chmod +x tools/bootstrap_context7_key.sh
+CONTEXT7_API_KEY=mysecretkey make -C tools context7-setup
+
+# or interactively (script will prompt if env not set):
+make -C tools context7-setup
+```
+
+This target writes/merges the key into `tools/.mcp_env` with secure file permissions (mode `600`).
+
+## Devcontainer
+
+- To provide the key to the devcontainer, add it to `.devcontainer/devcontainer.json` under `containerEnv`:
+
+```json
+"containerEnv": {
+  "CONTEXT7_API_KEY": "${localEnv:CONTEXT7_API_KEY}"
+}
+```
+
+## CI
+
+- In CI (GitHub Actions), store the key as a repository secret named `CONTEXT7_API_KEY` and expose it in workflow `env`.
+
+## Notes
+
+- The repository now contains a `tools/bootstrap_context7_key.sh` helper and a Makefile target `tools/context7-setup` to make local setup easier.

--- a/docs/MAKEFILE_USAGE.md
+++ b/docs/MAKEFILE_USAGE.md
@@ -1,5 +1,4 @@
-Makefile helper: CONTEXT7 key bootstrap
-=====================================
+# Makefile helper: CONTEXT7 key bootstrap
 
 This short document explains the `tools/context7-setup` Makefile target and the `tools/bootstrap_context7_key.sh` helper.
 

--- a/docs/MAKEFILE_USAGE.md
+++ b/docs/MAKEFILE_USAGE.md
@@ -1,0 +1,45 @@
+Makefile helper: CONTEXT7 key bootstrap
+=====================================
+
+This short document explains the `tools/context7-setup` Makefile target and the `tools/bootstrap_context7_key.sh` helper.
+
+Usage
+
+From the repository root:
+
+```bash
+# Make the helper executable (once)
+chmod +x tools/bootstrap_context7_key.sh
+
+# Provide the key via env and run the helper via make
+CONTEXT7_API_KEY=mysecretkey make -C tools context7-setup
+
+# Or run interactively (script will prompt if env not set):
+make -C tools context7-setup
+```
+
+What it does
+
+- Ensures `tools/bootstrap_context7_key.sh` is executable.
+- Runs the helper which merges/updates `CONTEXT7_API_KEY` into `tools/.mcp_env`.
+- The helper writes the file atomically and sets file permissions to `600`.
+
+Loading the env into your shell
+
+```bash
+set -a; source tools/.mcp_env; set +a
+```
+
+Devcontainer
+
+Add to `.devcontainer/devcontainer.json`:
+
+```json
+"containerEnv": {
+  "CONTEXT7_API_KEY": "${localEnv:CONTEXT7_API_KEY}"
+}
+```
+
+CI
+
+Store `CONTEXT7_API_KEY` as a repository secret and expose it in workflow `env`.

--- a/docs/README_MCP.md
+++ b/docs/README_MCP.md
@@ -1,0 +1,53 @@
+````markdown
+# MCP / CONTEXT7 key setup
+
+This document explains how the MCP entry in `mcp.json` expects the `CONTEXT7_API_KEY` to be provided, and documents the provided `tools/context7-setup` Makefile helper.
+
+## How the MCP reads the key
+
+- The MCP configuration prefers the environment variable `CONTEXT7_API_KEY`.
+- It will not prompt interactively; the MCP reads `${env:CONTEXT7_API_KEY}`.
+
+## Local development options
+
+- Create or update `tools/.mcp_env` and add `CONTEXT7_API_KEY=...`, then load it into your shell:
+
+```bash
+set -a; source tools/.mcp_env; set +a
+```
+````
+
+- Or use the helper Makefile target (from repo root):
+
+```bash
+# make the helper executable and run it
+chmod +x tools/bootstrap_context7_key.sh
+CONTEXT7_API_KEY=mysecretkey make -C tools context7-setup
+
+# or interactively (script will prompt if env not set):
+make -C tools context7-setup
+```
+
+This target writes/merges the key into `tools/.mcp_env` with secure file permissions (mode `600`).
+
+## Devcontainer
+
+- To provide the key to the devcontainer, add it to `.devcontainer/devcontainer.json` under `containerEnv`:
+
+```json
+"containerEnv": {
+  "CONTEXT7_API_KEY": "${localEnv:CONTEXT7_API_KEY}"
+}
+```
+
+## CI
+
+- In CI (GitHub Actions), store the key as a repository secret named `CONTEXT7_API_KEY` and expose it in workflow `env`.
+
+## Notes
+
+- The repository now contains a `tools/bootstrap_context7_key.sh` helper and a Makefile target `tools/context7-setup` to make local setup easier.
+
+```
+
+```


### PR DESCRIPTION
Adds README_MCP.md and docs/MAKEFILE_USAGE.md documenting the CONTEXT7 key setup and Makefile helper.