### PR TITLE
Enforce Q/D/Z-only defaults and C: exclusion for Windows drive organizer

### DIFF
--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -1,0 +1,83 @@
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import Iterable, List
+
+DEFAULT_DRIVES = [Path(r"Q:/"), Path(r"D:/"), Path(r"Z:/")]
+REQUIRED_DRIVES = {"Q:", "D:", "Z:"}
+
+
+def _drive_letter(path: Path) -> str:
+    return PureWindowsPath(str(path)).drive.upper()
+
+
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except TypeError:
+        return path.resolve()
+
+
+@dataclass
+class EvidenceOrganizer:
+    drives: List[Path]
+
+    def __init__(self, drives: Iterable[Path] | None = None) -> None:
+        self.drives = list(drives) if drives is not None else list(DEFAULT_DRIVES)
+
+    def _validate_drives(self) -> None:
+        drive_letters = {_drive_letter(drive) for drive in self.drives}
+        missing_required = REQUIRED_DRIVES - drive_letters
+        if missing_required:
+            missing = ", ".join(sorted(missing_required))
+            raise ValueError(f"Missing required drives: {missing}.")
+
+        missing_paths = [drive for drive in self.drives if not drive.exists()]
+        if missing_paths:
+            missing = ", ".join(str(path) for path in missing_paths)
+            raise FileNotFoundError(f"Required drives are not available: {missing}.")
+
+        invalid_c = []
+        for drive in self.drives:
+            for candidate in (drive, _resolve_path(drive)):
+                if _drive_letter(candidate) == "C:":
+                    invalid_c.append(str(drive))
+                    break
+
+        if invalid_c:
+            drives = ", ".join(invalid_c)
+            raise ValueError(f"C: drive roots are not permitted: {drives}.")
+
+    def _discover_files(self) -> List[Path]:
+        discovered = []
+        for drive in self.drives:
+            for root, _, files in os.walk(drive):
+                for filename in files:
+                    discovered.append(Path(root) / filename)
+        return discovered
+
+    def run(self) -> List[Path]:
+        self._validate_drives()
+        return self._discover_files()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evidence organizer drive scan")
+    parser.add_argument(
+        "--drives",
+        nargs="*",
+        default=[str(drive) for drive in DEFAULT_DRIVES],
+        help="Drive roots to scan (default: Q:/ D:/ Z:/)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    organizer = EvidenceOrganizer(drives=[Path(drive) for drive in args.drives])
+    organizer.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/windows_drive_organizer_runbook.md
+++ b/docs/windows_drive_organizer_runbook.md
@@ -1,0 +1,29 @@
+# Windows Drive Organizer Runbook
+
+## Default Drive Policy
+
+The Windows drive organizer scans only the Q, D, and Z drive roots by default. The default drive list is:
+
+- `Q:/`
+- `D:/`
+- `Z:/`
+
+These defaults are enforced in `cli/windows_drive_organizer.py`.
+
+## C: Drive Exclusion
+
+Drive roots that resolve to `C:` are explicitly rejected. This includes values like `C:/` or `C:\`, or any path that resolves to the C drive. The organizer fails closed if a `C:` root is detected.
+
+## Preflight Validation Behavior
+
+Before discovery begins, the organizer performs a preflight check:
+
+- All three required drives (`Q:`, `D:`, `Z:`) must be present.
+- Any missing required drive causes the run to stop immediately.
+- Any drive root that resolves to `C:` causes the run to stop immediately.
+
+## Example Usage
+
+```bash
+python cli/windows_drive_organizer.py --drives Q:/ D:/ Z:/
+```


### PR DESCRIPTION
### Motivation

- Align the Windows drive organizer with the Q/D/Z-only policy so scans target `Q:/`, `D:/`, and `Z:/` by default.
- Ensure a fail-closed stance so runs stop early if required drives are missing or a `C:` drive root is supplied.

### Description

- Replace default drive list with `DEFAULT_DRIVES = [Path(r"Q:/"), Path(r"D:/"), Path(r"Z:/")]` and add `REQUIRED_DRIVES = {"Q:", "D:", "Z:"}`.
- Add an `EvidenceOrganizer` class with a `_validate_drives` method that fails closed when any required drive is absent, verifies drive paths exist, and rejects any drive root that resolves to `C:` (including `C:/` or `C:\`).
- Call `_validate_drives()` at the start of `EvidenceOrganizer.run()` so validation occurs before discovery.
- Add `docs/windows_drive_organizer_runbook.md` documenting the Q/D/Z defaults and the explicit `C:` exclusion policy and showing example usage with `--drives`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969596e21308322968d681473b8f1b0)