### PR TITLE
Add denylist support to Windows drive organizer and document runbook

### DIFF
--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable, List, Set
+
+DEFAULT_DENY_DIRS = {
+    "Windows",
+    "Program Files",
+    "Program Files (x86)",
+    "$Recycle.Bin",
+    "System Volume Information",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    "venv",
+    "dist",
+    "build",
+}
+
+
+def _normalize_names(names: Iterable[str]) -> Set[str]:
+    return {name.strip().lower() for name in names if name.strip()}
+
+
+def _parse_deny_dirs(values: List[str]) -> List[str]:
+    parsed: List[str] = []
+    for value in values:
+        parsed.extend([part.strip() for part in value.split(",") if part.strip()])
+    return parsed
+
+
+def discover_files(root: Path, deny_dirs: Iterable[str]) -> List[Path]:
+    deny_names = _normalize_names(deny_dirs)
+    candidates: List[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            name for name in dirnames if name.strip().lower() not in deny_names
+        ]
+        for filename in filenames:
+            candidates.append(Path(dirpath) / filename)
+    return candidates
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Discover files on a Windows drive while skipping risky system folders."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="F:/",
+        help="Root path to scan (default F:/)",
+    )
+    parser.add_argument(
+        "--deny-dirs",
+        action="append",
+        default=[],
+        help=(
+            "Comma-separated list of directory names to deny. "
+            "Use 'none' to disable the default denylist."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    extras = _parse_deny_dirs(args.deny_dirs)
+    if any(value.lower() == "none" for value in extras):
+        deny_dirs = [value for value in extras if value.lower() != "none"]
+    else:
+        deny_dirs = list(DEFAULT_DENY_DIRS) + extras
+    root = Path(args.path)
+    if not root.exists():
+        raise SystemExit(f"Root path does not exist: {root}")
+    candidates = discover_files(root, deny_dirs)
+    print(f"Discovered {len(candidates)} files under {root}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -19,7 +19,7 @@ DEFAULT_DENY_DIRS = {
 
 
 def _normalize_names(names: Iterable[str]) -> Set[str]:
-    return {name.strip().lower() for name in names if name.strip()}
+    return {name.strip().casefold() for name in names if name.strip()}
 
 
 def _parse_deny_dirs(values: List[str]) -> List[str]:
@@ -34,7 +34,7 @@ def discover_files(root: Path, deny_dirs: Iterable[str]) -> List[Path]:
     candidates: List[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [
-            name for name in dirnames if name.strip().lower() not in deny_names
+            name for name in dirnames if name.strip().casefold() not in deny_names
         ]
         for filename in filenames:
             candidates.append(Path(dirpath) / filename)
@@ -66,8 +66,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     extras = _parse_deny_dirs(args.deny_dirs)
-    if any(value.lower() == "none" for value in extras):
-        deny_dirs = [value for value in extras if value.lower() != "none"]
+    if any(value.casefold() == "none" for value in extras):
+        deny_dirs = [value for value in extras if value.casefold() != "none"]
     else:
         deny_dirs = list(DEFAULT_DENY_DIRS) + extras
     root = Path(args.path)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,6 @@
 Repository documentation is organized in this directory. Key references:
 
 - [Bootstrap Environment Requirements](bootstrap_prerequisites.md) — all prerequisites and setup commands for `golden_god_mode_bootstrap.py`.
+- [Operations Runbook](RUNBOOK.md) — operational guidance and CLI behavior notes.
 
 Add additional documents here as the litigation workspace evolves.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,30 @@
+# Operations Runbook
+
+## Windows Drive Organizer
+
+`cli/windows_drive_organizer.py` scans a Windows drive while skipping high-risk/system
+folders by default. The denylist is matched against directory names (case-insensitive)
+and excludes the following directories and their children from discovery:
+
+- `Windows`
+- `Program Files`
+- `Program Files (x86)`
+- `$Recycle.Bin`
+- `System Volume Information`
+- `node_modules`
+- `.git`
+- `__pycache__`
+- `venv`
+- `dist`
+- `build`
+
+### Override or Extend the Denylist
+
+Use `--deny-dirs` to append additional directory names. Provide a comma-separated list
+or repeat the flag as needed. To replace the default denylist entirely, include `none`
+in the list.
+
+```bash
+python cli/windows_drive_organizer.py F:/ --deny-dirs "Temp,Cache"
+python cli/windows_drive_organizer.py F:/ --deny-dirs "none,CustomSafe"
+```


### PR DESCRIPTION
### Motivation
- Prevent scans from recursing into high-risk or system directories on Windows drives by default to reduce accidental reads/moves and improve safety. 
- Allow operators to extend or override the default denylist at runtime for situational needs. 
- Capture the denylist behavior and the override mechanism in project runbook documentation for operators.

### Description
- Add `cli/windows_drive_organizer.py` which defines `DEFAULT_DENY_DIRS` and implements `discover_files()` that filters `dirnames[:]` using a case-insensitive denylist match. 
- Provide `_parse_deny_dirs()` and `_normalize_names()` helpers plus a `--deny-dirs` CLI flag that accepts comma-separated values (repeatable) and supports `none` to disable the defaults. 
- Report discovered file count after scanning and validate the root path existence before scanning. 
- Add `docs/RUNBOOK.md` documenting denylist entries and override usage and update `docs/README.md` to link the new runbook.

### Testing
- No automated tests were executed for this change and no test files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695982896083228e5b2eff6985d149)