### PR TITLE
Add guarded output-root with C: drive protection for Windows drive organizer

### DIFF
--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -1,0 +1,80 @@
+"""Windows drive organizer with guarded output roots."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime
+from pathlib import Path, PureWindowsPath
+
+
+DEFAULT_OUTPUT_ROOT_TEMPLATE = "Z:/LitigationOS/Runs/{run_id}"
+
+
+class EvidenceOrganizer:
+    def __init__(self, output_root: Path, *, allow_c_drive: bool = False) -> None:
+        self.output_root = Path(output_root)
+        self.allow_c_drive = allow_c_drive
+        self._validate_output_root()
+        self.temp_dir = self.output_root / "TEMP"
+        self.logs_dir = self.output_root / "LOGS"
+        self._ensure_directories()
+
+    def _validate_output_root(self) -> None:
+        windows_path = PureWindowsPath(str(self.output_root))
+        if windows_path.drive.lower() == "c:" and not self.allow_c_drive:
+            raise ValueError(
+                "Output root on C: is blocked by default. "
+                "Use a Z: path or pass --allow-c-drive to override."
+            )
+
+    def _ensure_directories(self) -> None:
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        self.temp_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+
+def build_default_output_root(run_id: str) -> Path:
+    return Path(DEFAULT_OUTPUT_ROOT_TEMPLATE.format(run_id=run_id))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Windows drive organizer")
+    parser.add_argument(
+        "--output-root",
+        default=None,
+        help=(
+            "Output root directory. Defaults to "
+            f"{DEFAULT_OUTPUT_ROOT_TEMPLATE}."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional run identifier used in the default output path.",
+    )
+    parser.add_argument(
+        "--allow-c-drive",
+        action="store_true",
+        help="Allow output-root on C: (blocked by default).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_id = args.run_id or datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    output_root = Path(args.output_root) if args.output_root else build_default_output_root(run_id)
+
+    organizer = EvidenceOrganizer(output_root, allow_c_drive=args.allow_c_drive)
+
+    logging.basicConfig(
+        filename=str(organizer.logs_dir / "windows_drive_organizer.log"),
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    logging.info("Initialized EvidenceOrganizer at %s", organizer.output_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -21,8 +21,8 @@ class EvidenceOrganizer:
         self._ensure_directories()
 
     def _validate_output_root(self) -> None:
-        windows_path = PureWindowsPath(str(self.output_root))
-        if windows_path.drive.lower() == "c:" and not self.allow_c_drive:
+        pure_windows_path = PureWindowsPath(str(self.output_root))
+        if pure_windows_path.drive.lower() == "c:" and not self.allow_c_drive:
             raise ValueError(
                 "Output root on C: is blocked by default. "
                 "Use a Z: path or pass --allow-c-drive to override."

--- a/docs/windows_drive_organizer_runbook.md
+++ b/docs/windows_drive_organizer_runbook.md
@@ -1,0 +1,38 @@
+# Windows Drive Organizer Runbook
+
+## Output-root policy
+
+- The organizer writes **only** under the configured `--output-root`.
+- The default output root is on `Z:` to avoid accidental writes to `C:`.
+- Any `output_root` on `C:` is rejected unless you explicitly pass `--allow-c-drive`.
+- `TEMP` staging and `LOGS` directories are always created under the chosen output root.
+
+### Default output root
+
+If `--output-root` is not provided, the organizer uses:
+
+```
+Z:/LitigationOS/Runs/<RUN_ID>
+```
+
+`<RUN_ID>` is generated from the current UTC timestamp unless `--run-id` is provided.
+
+### Examples
+
+Use the safe default (creates `TEMP` and `LOGS` under Z:):
+
+```
+python cli/windows_drive_organizer.py
+```
+
+Specify a safe output root on `Z:`:
+
+```
+python cli/windows_drive_organizer.py --output-root "Z:/LitigationOS/Logs"
+```
+
+Override the C: drive guard (only when explicitly required):
+
+```
+python cli/windows_drive_organizer.py --output-root "C:/LitigationOS/Logs" --allow-c-drive
+```


### PR DESCRIPTION
### Motivation

- Prevent accidental writes to the system `C:` drive by using a safe default output path on `Z:` and adding an explicit opt-in to allow `C:` when required.
- Ensure all temporary staging and logs are colocated under the configured output root so they inherit the same drive policy.
- Provide clear operator documentation for the output-root policy and usage examples.

### Description

- Add `cli/windows_drive_organizer.py` which implements `EvidenceOrganizer` and uses `DEFAULT_OUTPUT_ROOT_TEMPLATE = "Z:/LitigationOS/Runs/{run_id}"` as the default when `--output-root` is not provided.
- Add a validation method that rejects `output_root` paths on `C:` unless `--allow-c-drive` is passed, implemented using `PureWindowsPath` and raising a `ValueError` when blocked.
- Ensure `TEMP` and `LOGS` directories are created under the chosen `output_root` (via `Path.mkdir(parents=True, exist_ok=True)`) and configure logging to write into `LOGS` under the output root.
- Add `docs/windows_drive_organizer_runbook.md` documenting the default path, `--output-root`, `--run-id`, and the `--allow-c-drive` override with examples.

### Testing

- No automated tests were run for this change (no test suite executed as part of the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696959857330832297c5ee7a2800c39e)