### PR TITLE
Add graphic gap checklist for LitigationOS graph

### DIFF
--- a/docs/GRAPH_GAPS.md
+++ b/docs/GRAPH_GAPS.md
@@ -1,4 +1,4 @@
-# Graphic Gap Checklist (LitigationOS Graph)
+# Graph Gap Checklist (LitigationOS Graph)
 
 ## Missing or Under-specified Components (Relative to Full Spec)
 - **SemanticEdge layer** for typed graph relationships (ENFORCES, INTERPRETS, SUPERSEDES, LIMITS, IMPLEMENTS, GUIDES, CONFLICTS).  

--- a/docs/GRAPH_GAPS.md
+++ b/docs/GRAPH_GAPS.md
@@ -1,0 +1,12 @@
+# Graphic Gap Checklist (LitigationOS Graph)
+
+## Missing or Under-specified Components (Relative to Full Spec)
+- **SemanticEdge layer** for typed graph relationships (ENFORCES, INTERPRETS, SUPERSEDES, LIMITS, IMPLEMENTS, GUIDES, CONFLICTS).  
+- **ProceduralPath/Track entities** to represent vehicle-first pathing, parallel tracks, and escalation routes.  
+- **Conflict/Denial nodes** to encode contradictions, denials, and counter-paths for denial-aware routing.  
+- **Assurance scoring (ADD)** structures for confidence bands, freshness decay, and conflict surfacing.  
+- **PoDP identity fields** (authority content hash, official source, effective date) and provenance linkage.  
+- **ContextPack + CEA artifacts** (claim → evidence → authority mapping and decision trace).  
+- **PCG execution gate metadata** beyond current gate result node (explicit proof obligations, irreversible action gating).  
+- **Case-state persistence** primitives (CASE_STATE, LEDGERΔ, REGISTRY append-only IDs/pointers).  
+- **Operator views** for “what to file / what’s missing / denial / appeal-ready” status.  


### PR DESCRIPTION
### Motivation
- Document gaps in the current LitigationOS graph graphic versus the project's graph/PoDP/ADD/PCG specification to guide follow-up design and implementation.

### Description
- Add `docs/GRAPH_GAPS.md` containing a concise checklist of missing or under-specified components, including SemanticEdge relationships, ProceduralPath/Track entities, Conflict/Denial nodes, ADD assurance scoring, PoDP identity/provenance fields, ContextPack+CEA artifacts, PCG gate metadata, Case-state persistence primitives, and operator views.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f92095cf48322ad3c907f3bf95419)