### PR TITLE
Validate Windows output root paths

### DIFF
--- a/cli/windows_drive_organizer.py
+++ b/cli/windows_drive_organizer.py
@@ -12,21 +12,47 @@ DEFAULT_OUTPUT_ROOT_TEMPLATE = "Z:/LitigationOS/Runs/{run_id}"
 
 
 class EvidenceOrganizer:
-    def __init__(self, output_root: Path, *, allow_c_drive: bool = False) -> None:
+    def __init__(
+        self,
+        output_root: Path,
+        *,
+        allow_c_drive: bool = False,
+        allow_relative_output: bool = False,
+    ) -> None:
         self.output_root = Path(output_root)
         self.allow_c_drive = allow_c_drive
+        self.allow_relative_output = allow_relative_output
         self._validate_output_root()
         self.temp_dir = self.output_root / "TEMP"
         self.logs_dir = self.output_root / "LOGS"
         self._ensure_directories()
 
     def _validate_output_root(self) -> None:
-        pure_windows_path = PureWindowsPath(str(self.output_root))
-        if pure_windows_path.drive.lower() == "c:" and not self.allow_c_drive:
+        original_windows_path = PureWindowsPath(str(self.output_root))
+        resolved_path = self.output_root.expanduser().resolve()
+        resolved_windows_path = PureWindowsPath(str(resolved_path))
+
+        if not original_windows_path.is_absolute() and not (
+            self.allow_c_drive or self.allow_relative_output
+        ):
+            raise ValueError(
+                "Output root must be an absolute Windows path with a drive letter or UNC path. "
+                f"Resolved path: {resolved_windows_path}. "
+                "Use --allow-relative-output or --allow-c-drive to override."
+            )
+        if not resolved_windows_path.drive:
+            raise ValueError(
+                "Output root must include a drive letter or UNC path. "
+                f"Resolved path: {resolved_windows_path}."
+            )
+        if resolved_windows_path.drive.lower() == "c:" and not self.allow_c_drive:
             raise ValueError(
                 "Output root on C: is blocked by default. "
+                f"Resolved path: {resolved_windows_path}. "
                 "Use a Z: path or pass --allow-c-drive to override."
             )
+
+        self.output_root = resolved_path
 
     def _ensure_directories(self) -> None:
         self.output_root.mkdir(parents=True, exist_ok=True)
@@ -58,6 +84,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Allow output-root on C: (blocked by default).",
     )
+    parser.add_argument(
+        "--allow-relative-output",
+        action="store_true",
+        help="Allow relative output paths (default requires absolute Windows path).",
+    )
     return parser.parse_args()
 
 
@@ -66,7 +97,11 @@ def main() -> None:
     run_id = args.run_id or datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     output_root = Path(args.output_root) if args.output_root else build_default_output_root(run_id)
 
-    organizer = EvidenceOrganizer(output_root, allow_c_drive=args.allow_c_drive)
+    organizer = EvidenceOrganizer(
+        output_root,
+        allow_c_drive=args.allow_c_drive,
+        allow_relative_output=args.allow_relative_output,
+    )
 
     logging.basicConfig(
         filename=str(organizer.logs_dir / "windows_drive_organizer.log"),


### PR DESCRIPTION
### Motivation
- Ensure the organizer uses a resolved absolute Windows path (drive letter or UNC) before creating directories to avoid accidental writes to inappropriate locations.
- Prevent use of the system `C:` drive by default for safety, while providing explicit overrides for exceptional cases.
- Provide clearer error messages that include the resolved path to aid troubleshooting when path resolution or drive detection fails.

### Description
- Modified `cli/windows_drive_organizer.py` to add an `allow_relative_output` option and wire it through `parse_args` and `EvidenceOrganizer.__init__` as `--allow-relative-output` and `allow_relative_output` respectively.
- In `EvidenceOrganizer._validate_output_root` the code now resolves the path via `Path.expanduser().resolve()` and uses `PureWindowsPath` to inspect the drive/UNC information before proceeding.
- The validator now rejects non-absolute/relative input unless `--allow-relative-output` or `--allow-c-drive` is provided, rejects paths without a drive/UNC, and rejects `C:` unless `--allow-c-drive` is set, and includes the `resolved_path` in the raised `ValueError` messages.
- After validation the instance `self.output_root` is set to the resolved absolute path and directory creation proceeds; the only modified file is `cli/windows_drive_organizer.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8ecde7e48322b561d2e04e944cc8)