### PR TITLE
Include strategy options in run manifest (Python + PowerShell) and extend organizer outputs

### DIFF
--- a/organize_drive.ps1
+++ b/organize_drive.ps1
@@ -1,114 +1,535 @@
-<#
-.SYNOPSIS
-Organizes files in a drive into categorized folders and removes empty directories.
-#>
+& {
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
-param(
-    [string]$Path = 'F:\',
-    [string]$Log = 'organize_drive.log',
-    [string]$Output = '',  # Optional custom output directory
-    [int]$MaxJobs = [Environment]::ProcessorCount
-)
+    # =========================
+    # CONFIG
+    # =========================
+    $SourceRoots = @(
+        'C:\Users\andrew'
+    )
 
-$ErrorActionPreference = 'Stop'
+    # Change if you want a different destination root
+    $DestinationRoot = 'E:\FileHistory\andre\THEMANBEARPIG\_ORGANIZED_BY_EXT_FROM_C_USERS_ANDREW'
 
-Start-Transcript -Path $Log -Append
+    $DoMove = $false                      # $false = COPY, $true = MOVE (COPY recommended initially)
+    $Dedupe = $true                       # exact duplicates by SHA-256
+    $DedupeAction = 'Quarantine'          # 'Quarantine' | 'Skip' | 'KeepAll'
+    $RemoveEmptySourceFolders = $false    # Only consider with MOVE, and only after you verify results
+    $SkipReparsePoints = $true            # skips junctions/symlinks to avoid loops
+    $ComputeSHA256 = $true                # required for dedupe
+    $RunSelfTest = $true                  # validates logic in a sandbox before touching your data
+    $SelfTestRuns = 10                    # repeat self-test N times for confidence
+    $SelfTestOnly = $false                # if true, exit after self-test without organizing
+    $RunManifestPath = ''                 # optional path to write a run manifest JSON
 
-$Categories = @{
-    'Documents' = '.pdf','.doc','.docx','.txt','.xls','.xlsx','.ppt','.pptx','.csv','.odt','.ods','.odp'
-    'Images'    = '.jpg','.jpeg','.png','.gif','.bmp','.tiff','.svg'
-    'Music'     = '.mp3','.wav','.flac','.aac','.ogg','.wma'
-    'Videos'    = '.mp4','.avi','.mkv','.mov','.wmv','.flv'
-    'Archives'  = '.zip','.rar','.7z','.tar','.gz','.bz2'
-    'Code'      = '.py','.js','.html','.css','.java','.c','.cpp','.cs','.rb','.php'
-}
+    # Exclusions inside your canonical folder (safe defaults)
+    $ExcludeRoots = @(
+        'C:\Users\andrew\AppData',
+        'C:\Users\andrew\OneDriveTemp',
+        'C:\Users\andrew\.cache',
+        'C:\Users\andrew\.nuget',
+        'C:\Users\andrew\.vscode',
+        'C:\Users\andrew\.git'
+    )
 
-$DefaultCategory = 'Other'
-$OrganizedFolder = 'Organized'
+    # =========================
+    # Helpers
+    # =========================
+    function Ensure-Dir([string]$Path) {
+        if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+    }
 
-function Get-Category {
-    param([string]$Extension)
-    foreach ($cat in $Categories.Keys) {
-        if ($Categories[$cat] -contains $Extension.ToLower()) {
-            return $cat
+    function Normalize-Root([string]$p) {
+        if ([string]::IsNullOrWhiteSpace($p)) { return $null }
+        $full = [System.IO.Path]::GetFullPath($p)
+        if ($full.EndsWith('\')) { return $full }
+        return $full + '\'
+    }
+
+    function Build-ExcludeList([string[]]$Roots) {
+        $list = New-Object System.Collections.Generic.List[string]
+        foreach ($r in $Roots) {
+            try {
+                $nr = Normalize-Root $r
+                if ($nr) { $list.Add($nr) }
+            } catch { }
+        }
+        return $list.ToArray()
+    }
+
+    function Is-ExcludedPath([string]$Path, [string[]]$ExcludeNorm) {
+        if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+        $p = $Path
+        if (-not $p.EndsWith('\')) { $p = $p + '\' }
+        foreach ($ex in $ExcludeNorm) {
+            if ($p.StartsWith($ex, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+        }
+        return $false
+    }
+
+    function To-LongPath([string]$Path) {
+        if ($Path -like '\\?\*') { return $Path }
+        if ($Path -like '\\*') { return "\\?\UNC\" + $Path.TrimStart('\\') }
+        return "\\?\" + $Path
+    }
+
+    function Get-StringMD5([string]$InputString) {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($InputString)
+            $hashBytes = $md5.ComputeHash($bytes)
+            return -join ($hashBytes | ForEach-Object { $_.ToString('x2') })
+        } finally { $md5.Dispose() }
+    }
+
+    function Get-FileSHA256([string]$Path) {
+        return (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash
+    }
+
+    function CopyOrMove-File([string]$Src, [string]$Dst, [bool]$Move) {
+        try {
+            if ($Move) { Move-Item -LiteralPath $Src -Destination $Dst -Force -ErrorAction Stop }
+            else { Copy-Item -LiteralPath $Src -Destination $Dst -Force -ErrorAction Stop }
+            return $true
+        } catch {
+            try {
+                $srcLP = To-LongPath $Src
+                $dstLP = To-LongPath $Dst
+                if ($Move) { [System.IO.File]::Move($srcLP, $dstLP) }
+                else { [System.IO.File]::Copy($srcLP, $dstLP, $true) }
+                return $true
+            } catch {
+                return $false
+            }
         }
     }
-    return $DefaultCategory
-}
 
-function Safe-Move {
-    param([string]$Source, [string]$Destination)
-    $destDir = Split-Path $Destination -Parent
-    if (!(Test-Path $destDir)) { New-Item -ItemType Directory -Path $destDir | Out-Null }
-    $base = [System.IO.Path]::GetFileNameWithoutExtension($Destination)
-    $ext  = [System.IO.Path]::GetExtension($Destination)
-    $dest = $Destination
-    $counter = 1
-    while (Test-Path $dest) {
-        $dest = Join-Path $destDir "${base}_${counter}${ext}"
-        $counter++
+    function Get-FilesSafe([string]$Root, [bool]$SkipReparse, [string[]]$ExcludeNorm) {
+        $rootFull = [System.IO.Path]::GetFullPath($Root)
+        if (Is-ExcludedPath -Path $rootFull -ExcludeNorm $ExcludeNorm) { return }
+
+        $rootDI = New-Object System.IO.DirectoryInfo($rootFull)
+        $stack = New-Object System.Collections.Stack
+        $stack.Push($rootDI)
+
+        while ($stack.Count -gt 0) {
+            $dir = $stack.Pop()
+            try {
+                if (Is-ExcludedPath -Path $dir.FullName -ExcludeNorm $ExcludeNorm) { continue }
+
+                foreach ($sub in $dir.GetDirectories()) {
+                    if ($SkipReparse -and (($sub.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) { continue }
+                    if (Is-ExcludedPath -Path $sub.FullName -ExcludeNorm $ExcludeNorm) { continue }
+                    $stack.Push($sub)
+                }
+
+                foreach ($file in $dir.GetFiles()) {
+                    if ($SkipReparse -and (($file.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) { continue }
+                    $file
+                }
+            } catch {
+                continue
+            }
+        }
     }
-    Move-Item -LiteralPath $Source -Destination $dest
-}
 
-function Remove-EmptyDirs {
-    param([string]$BasePath)
-    Get-ChildItem -Path $BasePath -Directory -Recurse |
-        Sort-Object -Property FullName -Descending |
-        ForEach-Object {
-            if (-not (Get-ChildItem -LiteralPath $_.FullName -Recurse -Force)) {
+    function Remove-EmptyDirs([string[]]$Roots, [string[]]$ExcludeNorm) {
+        foreach ($r in $Roots) {
+            if (-not (Test-Path -LiteralPath $r)) { continue }
+            $rFull = [System.IO.Path]::GetFullPath($r)
+            if (Is-ExcludedPath -Path $rFull -ExcludeNorm $ExcludeNorm) { continue }
+
+            $dirs = Get-ChildItem -LiteralPath $rFull -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+                Sort-Object { $_.FullName.Length } -Descending
+
+            foreach ($d in $dirs) {
                 try {
-                    Remove-Item -LiteralPath $_.FullName -Force
-                    Write-Host "Removed empty directory $($_.FullName)"
-                } catch {
-                    Write-Warning "Failed to remove $($_.FullName): $_"
+                    if (Is-ExcludedPath -Path $d.FullName -ExcludeNorm $ExcludeNorm) { continue }
+                    $hasFiles = Get-ChildItem -LiteralPath $d.FullName -File -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+                    $hasDirs  = Get-ChildItem -LiteralPath $d.FullName -Directory -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+                    if (-not $hasFiles -and -not $hasDirs) {
+                        Remove-Item -LiteralPath $d.FullName -Force -ErrorAction SilentlyContinue
+                    }
+                } catch { }
+            }
+        }
+    }
+
+    function Write-RowCsv([string]$CsvPath, [object]$Obj) {
+        if (-not (Test-Path -LiteralPath $CsvPath)) {
+            $Obj | Export-Csv -LiteralPath $CsvPath -NoTypeInformation -Encoding UTF8
+        } else {
+            $Obj | Export-Csv -LiteralPath $CsvPath -NoTypeInformation -Append -Encoding UTF8
+        }
+    }
+
+    function Write-RowJsonl([string]$JsonlPath, [object]$Obj) {
+        ($Obj | ConvertTo-Json -Compress) | Add-Content -LiteralPath $JsonlPath -Encoding UTF8
+    }
+
+    function Get-ExtBucket([System.IO.FileInfo]$File) {
+        $ext = $File.Extension
+        if ([string]::IsNullOrWhiteSpace($ext)) { return '_no_extension' }
+        $clean = $ext.TrimStart('.').ToLowerInvariant()
+        if ([string]::IsNullOrWhiteSpace($clean)) { return '_no_extension' }
+        return $clean
+    }
+
+    function Get-UniqueDestName([System.IO.FileInfo]$File, [string]$SrcLeaf) {
+        $pathHash = (Get-StringMD5 -InputString $File.FullName).Substring(0, 10)
+        return "{0}__{1}__{2}" -f $SrcLeaf, $pathHash, $File.Name
+    }
+
+    function Invoke-OrganizeByExtension {
+        param(
+            [string[]]$Sources,
+            [string]$DestRoot,
+            [bool]$MoveMode,
+            [bool]$DoDedupe,
+            [string]$DupAction,
+            [bool]$SkipReparse,
+            [bool]$DoHash,
+            [string[]]$ExcludeNorm
+        )
+
+        Ensure-Dir $DestRoot
+        $logsDir = Join-Path $DestRoot '__LOGS'
+        $dupsDir = Join-Path $DestRoot '__DUPLICATES'
+        Ensure-Dir $logsDir
+        if ($DoDedupe -and ($DupAction -eq 'Quarantine')) { Ensure-Dir $dupsDir }
+
+        $ts = (Get-Date).ToString('yyyyMMdd_HHmmss')
+        $csvLog = Join-Path $logsDir ("organize_by_ext_{0}.csv" -f $ts)
+        $jsonl  = Join-Path $logsDir ("organize_by_ext_{0}.jsonl" -f $ts)
+
+        $hashIndex = @{}   # sha256 -> primary dest path
+        $counts = @{
+            COPIED = 0; MOVED = 0; DUP_SKIPPED = 0; DUP_QUARANTINED = 0; FAILED = 0; SOURCE_MISSING = 0
+        }
+
+        foreach ($srcRoot in $Sources) {
+            if ([string]::IsNullOrWhiteSpace($srcRoot)) { continue }
+            if (-not (Test-Path -LiteralPath $srcRoot)) {
+                $counts.SOURCE_MISSING++
+                $row = [pscustomobject]@{
+                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                    action   = 'SOURCE_MISSING'
+                    source_root = $srcRoot
+                    source   = $null
+                    dest     = $null
+                    ext      = $null
+                    bytes    = $null
+                    sha256   = $null
+                    note     = $null
+                    error    = $null
+                }
+                Write-RowCsv  $csvLog $row
+                Write-RowJsonl $jsonl $row
+                continue
+            }
+
+            $srcLeaf = Split-Path -Path $srcRoot -Leaf
+            if ([string]::IsNullOrWhiteSpace($srcLeaf)) { $srcLeaf = 'andrew' }
+
+            $files = @(Get-FilesSafe -Root $srcRoot -SkipReparse:$SkipReparse -ExcludeNorm $ExcludeNorm)
+
+            foreach ($f in $files) {
+                $extBucket = Get-ExtBucket $f
+                $extDir = Join-Path $DestRoot $extBucket
+                Ensure-Dir $extDir
+
+                $destName = Get-UniqueDestName -File $f -SrcLeaf $srcLeaf
+                $destPath = Join-Path $extDir $destName
+
+                $sha = $null
+                if ($DoHash -or $DoDedupe) {
+                    try { $sha = Get-FileSHA256 -Path $f.FullName } catch { $sha = $null }
+                }
+
+                if ($DoDedupe -and $sha) {
+                    if ($hashIndex.ContainsKey($sha)) {
+                        if ($DupAction -eq 'Skip') {
+                            $counts.DUP_SKIPPED++
+                            $row = [pscustomobject]@{
+                                time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                action   = 'DUPLICATE_SKIPPED'
+                                source_root = $srcRoot
+                                source   = $f.FullName
+                                dest     = $null
+                                ext      = $extBucket
+                                bytes    = $f.Length
+                                sha256   = $sha
+                                note     = "primary=" + $hashIndex[$sha]
+                                error    = $null
+                            }
+                            Write-RowCsv  $csvLog $row
+                            Write-RowJsonl $jsonl $row
+                            continue
+                        }
+
+                        if ($DupAction -eq 'Quarantine') {
+                            $qDir = Join-Path $dupsDir $extBucket
+                            Ensure-Dir $qDir
+                            $qPath = Join-Path $qDir $destName
+
+                            $okQ = CopyOrMove-File -Src $f.FullName -Dst $qPath -Move:$MoveMode
+                            if ($okQ) {
+                                $counts.DUP_QUARANTINED++
+                                $row = [pscustomobject]@{
+                                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                    action   = $(if ($MoveMode) { 'DUPLICATE_MOVED_TO_QUARANTINE' } else { 'DUPLICATE_COPIED_TO_QUARANTINE' })
+                                    source_root = $srcRoot
+                                    source   = $f.FullName
+                                    dest     = $qPath
+                                    ext      = $extBucket
+                                    bytes    = $f.Length
+                                    sha256   = $sha
+                                    note     = "primary=" + $hashIndex[$sha]
+                                    error    = $null
+                                }
+                                Write-RowCsv  $csvLog $row
+                                Write-RowJsonl $jsonl $row
+                                continue
+                            } else {
+                                $counts.FAILED++
+                                $row = [pscustomobject]@{
+                                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                    action   = 'FAILED_DUP_QUARANTINE'
+                                    source_root = $srcRoot
+                                    source   = $f.FullName
+                                    dest     = $qPath
+                                    ext      = $extBucket
+                                    bytes    = $f.Length
+                                    sha256   = $sha
+                                    note     = "primary=" + $hashIndex[$sha]
+                                    error    = 'CopyOrMove failed'
+                                }
+                                Write-RowCsv  $csvLog $row
+                                Write-RowJsonl $jsonl $row
+                                continue
+                            }
+                        }
+                    }
+                }
+
+                $ok = CopyOrMove-File -Src $f.FullName -Dst $destPath -Move:$MoveMode
+                if ($ok) {
+                    if ($MoveMode) { $counts.MOVED++ } else { $counts.COPIED++ }
+                    if ($DoDedupe -and $sha -and (-not $hashIndex.ContainsKey($sha))) { $hashIndex[$sha] = $destPath }
+
+                    $row = [pscustomobject]@{
+                        time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                        action   = $(if ($MoveMode) { 'MOVED' } else { 'COPIED' })
+                        source_root = $srcRoot
+                        source   = $f.FullName
+                        dest     = $destPath
+                        ext      = $extBucket
+                        bytes    = $f.Length
+                        sha256   = $sha
+                        note     = $null
+                        error    = $null
+                    }
+                    Write-RowCsv  $csvLog $row
+                    Write-RowJsonl $jsonl $row
+                } else {
+                    $counts.FAILED++
+                    $row = [pscustomobject]@{
+                        time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                        action   = 'FAILED'
+                        source_root = $srcRoot
+                        source   = $f.FullName
+                        dest     = $destPath
+                        ext      = $extBucket
+                        bytes    = $f.Length
+                        sha256   = $sha
+                        note     = $null
+                        error    = 'CopyOrMove failed'
+                    }
+                    Write-RowCsv  $csvLog $row
+                    Write-RowJsonl $jsonl $row
                 }
             }
         }
-}
 
-function Move-FileJob {
-    param($File, $BaseOutput)
+        $indexPath = Join-Path $logsDir ("index_by_ext_{0}.csv" -f $ts)
+        $extDirs = Get-ChildItem -LiteralPath $DestRoot -Directory -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notin @('__LOGS','__DUPLICATES') }
+
+        $idxRows = foreach ($d in $extDirs) {
+            $files = @(Get-ChildItem -LiteralPath $d.FullName -File -Force -ErrorAction SilentlyContinue)
+            $total = 0L
+            foreach ($ff in $files) { $total += [int64]$ff.Length }
+            [pscustomobject]@{
+                ext_bucket  = $d.Name
+                file_count  = $files.Count
+                total_bytes = $total
+                folder      = $d.FullName
+            }
+        }
+        $idxRows | Sort-Object file_count -Descending | Export-Csv -LiteralPath $indexPath -NoTypeInformation -Encoding UTF8
+
+        return [pscustomobject]@{
+            DestinationRoot = $DestRoot
+            CsvLog          = $csvLog
+            JsonlLog        = $jsonl
+            IndexByExt      = $indexPath
+            Counts          = $counts
+        }
+    }
+
+    function Invoke-SelfTest {
+        $guid = [Guid]::NewGuid().ToString('N')
+        $base = Join-Path $env:TEMP ("OrgByExt_SelfTest_{0}" -f $guid)
+        $src1 = Join-Path $base 'src1'
+        $src2 = Join-Path $base 'src2'
+        $dst  = Join-Path $base 'dst'
+
+        $exNorm = Build-ExcludeList -Roots @()
+
+        try {
+            Ensure-Dir $src1
+            Ensure-Dir $src2
+            Ensure-Dir $dst
+            Ensure-Dir (Join-Path $src1 'nested')
+            Ensure-Dir (Join-Path $src2 'nested')
+
+            Set-Content -LiteralPath (Join-Path $src1 'a.txt') -Value 'same-content' -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'b.txt') -Value 'same-content' -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src1 'c.pdf') -Value 'pdf-content'  -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'd')     -Value 'noext'        -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src1 'nested\e.jpg') -Value 'img'  -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'nested\f.jpg') -Value 'img2' -Encoding UTF8
+
+            $r = Invoke-OrganizeByExtension -Sources @($src1,$src2) -DestRoot $dst -MoveMode:$false -DoDedupe:$true -DupAction:'Quarantine' -SkipReparse:$true -DoHash:$true -ExcludeNorm $exNorm
+
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'txt'))) { throw 'SelfTest: missing txt folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'pdf'))) { throw 'SelfTest: missing pdf folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'jpg'))) { throw 'SelfTest: missing jpg folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst '_no_extension'))) { throw 'SelfTest: missing _no_extension folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path (Join-Path $dst '__DUPLICATES') 'txt'))) { throw 'SelfTest: missing dup quarantine txt folder' }
+            if (-not (Test-Path -LiteralPath $r.CsvLog)) { throw 'SelfTest: missing CSV log' }
+            if (-not (Test-Path -LiteralPath $r.IndexByExt)) { throw 'SelfTest: missing index_by_ext CSV' }
+
+            $txtPrimary = @(Get-ChildItem -LiteralPath (Join-Path $dst 'txt') -File -Force -ErrorAction SilentlyContinue)
+            $txtDup = @(Get-ChildItem -LiteralPath (Join-Path (Join-Path $dst '__DUPLICATES') 'txt') -File -Force -ErrorAction SilentlyContinue)
+            if ($txtPrimary.Count -ne 1) { throw "SelfTest: expected 1 primary txt file, got $($txtPrimary.Count)" }
+            if ($txtDup.Count -ne 1) { throw "SelfTest: expected 1 quarantined dup txt file, got $($txtDup.Count)" }
+
+            return $true
+        } finally {
+            try { Remove-Item -LiteralPath $base -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+        }
+    }
+
+    # =========================
+    # MAIN
+    # =========================
     try {
-        $category = Get-Category $File.Extension
-        $destDir = Join-Path $BaseOutput $category
-        $destination = Join-Path $destDir $File.Name
-        Safe-Move -Source $File.FullName -Destination $destination
-        Write-Host "Moved $($File.FullName) -> $destination"
-    } catch {
-        Write-Warning "Failed to move $($File.FullName): $_"
+        if ($Dedupe -and ($DedupeAction -notin @('Quarantine','Skip','KeepAll'))) {
+            throw "Invalid DedupeAction. Use: Quarantine, Skip, KeepAll."
+        }
+
+        $excludeNorm = Build-ExcludeList -Roots $ExcludeRoots
+
+        Write-Host "Organize start : $([DateTime]::Now.ToString('o'))"
+        Write-Host "Source         : C:\Users\andrew"
+        Write-Host "Mode           : $(if ($DoMove) { 'MOVE' } else { 'COPY' })"
+        Write-Host "Destination    : $DestinationRoot"
+        Write-Host "Group by ext   : YES"
+        Write-Host "Dedupe         : $Dedupe"
+        Write-Host "DedupeAction   : $DedupeAction"
+        Write-Host "Skip reparse   : $SkipReparsePoints"
+        Write-Host "Exclude roots  :"
+        foreach ($x in $excludeNorm) { Write-Host "  - $x" }
+        Write-Host ""
+
+        if ($RunSelfTest) {
+            for ($i = 1; $i -le $SelfTestRuns; $i++) {
+                Write-Host "Self-test (temp sandbox) running... ($i/$SelfTestRuns)"
+                $ok = Invoke-SelfTest
+                if (-not $ok) { throw "Self-test returned failure." }
+            }
+            Write-Host "Self-test: PASS ($SelfTestRuns runs)"
+            Write-Host ""
+            if ($SelfTestOnly) {
+                Write-Host "Self-test-only mode enabled. Exiting."
+                return
+            }
+        }
+
+        Ensure-Dir $DestinationRoot
+
+        $result = Invoke-OrganizeByExtension `
+            -Sources $SourceRoots `
+            -DestRoot $DestinationRoot `
+            -MoveMode:$DoMove `
+            -DoDedupe:$Dedupe `
+            -DupAction:$DedupeAction `
+            -SkipReparse:$SkipReparsePoints `
+            -DoHash:$ComputeSHA256 `
+            -ExcludeNorm $excludeNorm
+
+        if ($DoMove -and $RemoveEmptySourceFolders) {
+            Write-Host "Removing empty folders under source roots (excluding protected roots)..."
+            Remove-EmptyDirs -Roots $SourceRoots -ExcludeNorm $excludeNorm
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($RunManifestPath)) {
+            $manifest = [pscustomobject]@{
+                generated_utc     = (Get-Date).ToUniversalTime().ToString('o')
+                sources           = $SourceRoots
+                destination       = $DestinationRoot
+                move_mode         = $DoMove
+                dedupe            = $Dedupe
+                dedupe_action     = if ($Dedupe) { $DedupeAction } else { 'OFF' }
+                remove_empty_dirs = $RemoveEmptySourceFolders
+                exclude_roots     = $excludeNorm
+                logs              = [pscustomobject]@{
+                    csv_log   = $result.CsvLog
+                    jsonl_log = $result.JsonlLog
+                    index_csv = $result.IndexByExt
+                }
+                counts            = $result.Counts
+                strategy_options  = @(
+                    [pscustomobject]@{
+                        option                    = 'Hypervisor: full-plane tranche convergence'
+                        next_best_action          = 'Turn on the hypervisor and execute tranche families across all planes until convergence, enforcing NONCORE → CORE promotion when risk crosses threshold.'
+                        super_set_generation_rules = 'Every cycle emits RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, STRATUM_METRICS.csv, VRpt.md, TRANCHE_RUNS.csv, PARALLEL_TRACK_STATUS.json. Stop only when Δ(new_nodes,new_edges,new_terms) < EPS for N cycles and VRpt PASS for the same streak.'
+                        add_on_modes              = @('@HYPERVISOR_ON','@AUTONOMY_MAX','@SHARD_BY_DOC','@BACKPRESSURE','@MULTIMODAL_POOLS','@PROMOTE_NONCORE_TO_CORE','@STRICT','@REPLAYABLE_RUN','@CONVERGENCE_EPS','@VRPT_PASS_STREAK','@TOROIDAL_SHARDING')
+                        enterprise_spec_pattern   = 'EXPLODE_SUPERPIN:HYPERVISOR @HYPERVISOR_ON @AUTONOMY_MAX @TOROIDAL_SHARDING @BACKPRESSURE @PROMOTE_NONCORE_TO_CORE @STRICT ?EPS=0.005&N=3&OUT=ZIP+MD+CSV+JSON&ITER=auto&STRICT=true'
+                    }
+                    [pscustomobject]@{
+                        option                    = 'Neo4j nucleus: schema contract + constraints-first + deterministic import + offline viewer'
+                        next_best_action          = 'Generate the Neo4j nucleus stack, then iterate until nucleus membership stabilizes for N cycles with VRpt PASS stability, focusing strata AUTHORITY, DECISIONS, ENFORCEMENT, with toroidal sharding tranche routing.'
+                        super_set_generation_rules = 'Every cycle emits schema_contract.json, constraints.cypher, import.cypher, split nodes.csv/edges.csv, nucleus/seeds.json, viewer/index.html, plus RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, STRATUM_METRICS.csv, VRpt.md. Stop only when nucleus membership stable N cycles and VRpt PASS N cycles.'
+                        add_on_modes              = @('@NEO4J_NUCLEUS','@SCHEMA_LOCK','@CONSTRAINTS_FIRST','@DETERMINISTIC_IMPORT','@NUCLEUS_SEED','@STRATUM_FOCUS=AUTHORITY,DECISIONS,ENFORCEMENT','@VIEWER_OFFLINE','@MANIFEST_VERIFY','@SELFTEST','@STRICT','@TOROIDAL_SHARDING')
+                        enterprise_spec_pattern   = 'EXPLODE_SUPERPIN:GRAPH @NEO4J_NUCLEUS @SCHEMA_LOCK @CONSTRAINTS_FIRST @DETERMINISTIC_IMPORT @NUCLEUS_SEED @STRATUM_FOCUS=AUTHORITY,DECISIONS,ENFORCEMENT @VIEWER_OFFLINE @MANIFEST_VERIFY @SELFTEST @STRICT ?OUT=ZIP+CSV+JSON+HTML+MD&ITER=auto&STRICT=true'
+                    }
+                    [pscustomobject]@{
+                        option                    = 'Forms-first Vehicle Router: Relief → Form → Standard → Elements → POs → Deadlines → Service → Exhibits'
+                        next_best_action          = 'Execute Forms-First Vehicle Router end-to-end with PO promotion logic enabled, fail-closed if any CORE obligations, deadlines, service, or VRpt are uncertain.'
+                        super_set_generation_rules = 'Every cycle emits VehicleMap.md, PO_DB.csv, Deadlines.csv, ServicePlan.md, ExhibitMatrix.csv, plus RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, STRATUM_METRICS.csv, VRpt.md. Packaging blocked if any CORE PO is OPEN or PARTIAL.'
+                        add_on_modes              = @('@PCW','@FORMSFIRST','@VEHICLE_MAP','@PO_DB_BUILD','@DEADLINE_ENGINE','@SERVICE_CHAIN','@EXHIBIT_MATRIX','@QUOTELOCK','@PROMOTE_NONCORE_TO_CORE','@FAIL_CLOSED','@STRICT')
+                        enterprise_spec_pattern   = 'EXPLODE_SUPERPIN:FORMS @PCW @FORMSFIRST @VEHICLE_MAP @PO_DB_BUILD @DEADLINE_ENGINE @SERVICE_CHAIN @EXHIBIT_MATRIX @PROMOTE_NONCORE_TO_CORE @FAIL_CLOSED @STRICT ?PIPE=RELIEF>FORM>STANDARD>ELEMENTS>PO>DEADLINES>SERVICE>EXHIBITS&OUT=ZIP+MD+CSV+JSON&ITER=auto&STRICT=true'
+                    }
+                )
+            }
+            $manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $RunManifestPath -Encoding UTF8
+        }
+
+        Write-Host ""
+        Write-Host "Organize complete: $([DateTime]::Now.ToString('o'))"
+        Write-Host "Destination      : $($result.DestinationRoot)"
+        Write-Host "Index (by ext)   : $($result.IndexByExt)"
+        Write-Host "CSV Log          : $($result.CsvLog)"
+        Write-Host "JSONL Log        : $($result.JsonlLog)"
+        Write-Host "Counts           : COPIED=$($result.Counts.COPIED) MOVED=$($result.Counts.MOVED) DUP_SKIPPED=$($result.Counts.DUP_SKIPPED) DUP_QUARANTINED=$($result.Counts.DUP_QUARANTINED) FAILED=$($result.Counts.FAILED) SOURCE_MISSING=$($result.Counts.SOURCE_MISSING)"
+    }
+    catch {
+        Write-Host ""
+        Write-Host "FATAL: $($_.Exception.Message)"
+        Write-Host "STACK: $($_.ScriptStackTrace)"
+        throw
     }
 }
-
-$target = Resolve-Path $Path
-if ($Output) {
-    $baseOutput = Resolve-Path $Output
-} else {
-    $baseOutput = Join-Path $target $OrganizedFolder
-}
-if (!(Test-Path $baseOutput)) { New-Item -ItemType Directory -Path $baseOutput | Out-Null }
-
-$files = Get-ChildItem -Path $target -File -Recurse | Where-Object { $_.FullName -notmatch "\\$OrganizedFolder(\\|$)" }
-$total = $files.Count
-$index = 0
-
-Import-Module ThreadJob -ErrorAction SilentlyContinue
-$jobs = @()
-foreach ($f in $files) {
-    $index++
-    $percent = [int](($index / $total) * 100)
-    Write-Progress -Activity "Organizing files" -Status "$index of $total" -PercentComplete $percent
-    $jobs += Start-ThreadJob -ScriptBlock ${function:Move-FileJob} -ArgumentList $f, $baseOutput
-    if ($jobs.Count -ge $MaxJobs) {
-        Wait-Job -Job $jobs -Any | Receive-Job
-        $jobs = $jobs | Where-Object { $_.State -eq 'Running' }
-    }
-}
-
-if ($jobs) { Wait-Job $jobs | Receive-Job }
-Write-Progress -Activity "Organizing files" -Completed
-
-Remove-EmptyDirs -BasePath $target
-
-Stop-Transcript
-Write-Host 'Organization complete.'

--- a/organize_drive.py
+++ b/organize_drive.py
@@ -1,241 +1,1212 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
 import os
 import shutil
-import argparse
-import logging
-import platform
-from concurrent.futures import ThreadPoolExecutor
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from tqdm import tqdm
+from typing import Iterable, Iterator
 
-# Mapping of file extensions to categories
-CATEGORIES = {
-    "Documents": [
-        ".pdf",
-        ".doc",
-        ".docx",
-        ".txt",
-        ".xls",
-        ".xlsx",
-        ".ppt",
-        ".pptx",
-        ".csv",
-        ".odt",
-        ".ods",
-        ".odp",
-    ],
-    "Images": [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".svg"],
-    "Music": [".mp3", ".wav", ".flac", ".aac", ".ogg", ".wma"],
-    "Videos": [".mp4", ".avi", ".mkv", ".mov", ".wmv", ".flv"],
-    "Archives": [".zip", ".rar", ".7z", ".tar", ".gz", ".bz2"],
-    "Code": [
-        ".py",
-        ".js",
-        ".html",
-        ".css",
-        ".java",
-        ".c",
-        ".cpp",
-        ".cs",
-        ".rb",
-        ".php",
-    ],
-}
+VERSION = "2.0.0"
+STRATEGY_OPTIONS = [
+    {
+        "option": "Hypervisor: full-plane tranche convergence",
+        "next_best_action": (
+            "Turn on the hypervisor and execute tranche families across all planes until "
+            "convergence, enforcing NONCORE → CORE promotion when risk crosses threshold."
+        ),
+        "super_set_generation_rules": (
+            "Every cycle emits RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, "
+            "STRATUM_METRICS.csv, VRpt.md, TRANCHE_RUNS.csv, PARALLEL_TRACK_STATUS.json. "
+            "Stop only when Δ(new_nodes,new_edges,new_terms) < EPS for N cycles and VRpt PASS "
+            "for the same streak."
+        ),
+        "add_on_modes": [
+            "@HYPERVISOR_ON",
+            "@AUTONOMY_MAX",
+            "@SHARD_BY_DOC",
+            "@BACKPRESSURE",
+            "@MULTIMODAL_POOLS",
+            "@PROMOTE_NONCORE_TO_CORE",
+            "@STRICT",
+            "@REPLAYABLE_RUN",
+            "@CONVERGENCE_EPS",
+            "@VRPT_PASS_STREAK",
+            "@TOROIDAL_SHARDING",
+        ],
+        "enterprise_spec_pattern": (
+            "EXPLODE_SUPERPIN:HYPERVISOR @HYPERVISOR_ON @AUTONOMY_MAX "
+            "@TOROIDAL_SHARDING @BACKPRESSURE @PROMOTE_NONCORE_TO_CORE @STRICT "
+            "?EPS=0.005&N=3&OUT=ZIP+MD+CSV+JSON&ITER=auto&STRICT=true"
+        ),
+    },
+    {
+        "option": "Neo4j nucleus: schema contract + constraints-first + deterministic import + offline viewer",
+        "next_best_action": (
+            "Generate the Neo4j nucleus stack, then iterate until nucleus membership "
+            "stabilizes for N cycles with VRpt PASS stability, focusing strata "
+            "AUTHORITY, DECISIONS, ENFORCEMENT, with toroidal sharding tranche routing."
+        ),
+        "super_set_generation_rules": (
+            "Every cycle emits schema_contract.json, constraints.cypher, import.cypher, "
+            "split nodes.csv/edges.csv, nucleus/seeds.json, viewer/index.html, plus "
+            "RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, STRATUM_METRICS.csv, VRpt.md. "
+            "Stop only when nucleus membership stable N cycles and VRpt PASS N cycles."
+        ),
+        "add_on_modes": [
+            "@NEO4J_NUCLEUS",
+            "@SCHEMA_LOCK",
+            "@CONSTRAINTS_FIRST",
+            "@DETERMINISTIC_IMPORT",
+            "@NUCLEUS_SEED",
+            "@STRATUM_FOCUS=AUTHORITY,DECISIONS,ENFORCEMENT",
+            "@VIEWER_OFFLINE",
+            "@MANIFEST_VERIFY",
+            "@SELFTEST",
+            "@STRICT",
+            "@TOROIDAL_SHARDING",
+        ],
+        "enterprise_spec_pattern": (
+            "EXPLODE_SUPERPIN:GRAPH @NEO4J_NUCLEUS @SCHEMA_LOCK @CONSTRAINTS_FIRST "
+            "@DETERMINISTIC_IMPORT @NUCLEUS_SEED "
+            "@STRATUM_FOCUS=AUTHORITY,DECISIONS,ENFORCEMENT @VIEWER_OFFLINE "
+            "@MANIFEST_VERIFY @SELFTEST @STRICT ?OUT=ZIP+CSV+JSON+HTML+MD&ITER=auto&STRICT=true"
+        ),
+    },
+    {
+        "option": "Forms-first Vehicle Router: Relief → Form → Standard → Elements → POs → Deadlines → Service → Exhibits",
+        "next_best_action": (
+            "Execute Forms-First Vehicle Router end-to-end with PO promotion logic enabled, "
+            "fail-closed if any CORE obligations, deadlines, service, or VRpt are uncertain."
+        ),
+        "super_set_generation_rules": (
+            "Every cycle emits VehicleMap.md, PO_DB.csv, Deadlines.csv, ServicePlan.md, "
+            "ExhibitMatrix.csv, plus RUN_LEDGER.jsonl, MANIFEST.json, DELTA_SUMMARY.md, "
+            "STRATUM_METRICS.csv, VRpt.md. Packaging blocked if any CORE PO is OPEN or PARTIAL."
+        ),
+        "add_on_modes": [
+            "@PCW",
+            "@FORMSFIRST",
+            "@VEHICLE_MAP",
+            "@PO_DB_BUILD",
+            "@DEADLINE_ENGINE",
+            "@SERVICE_CHAIN",
+            "@EXHIBIT_MATRIX",
+            "@QUOTELOCK",
+            "@PROMOTE_NONCORE_TO_CORE",
+            "@FAIL_CLOSED",
+            "@STRICT",
+        ],
+        "enterprise_spec_pattern": (
+            "EXPLODE_SUPERPIN:FORMS @PCW @FORMSFIRST @VEHICLE_MAP @PO_DB_BUILD "
+            "@DEADLINE_ENGINE @SERVICE_CHAIN @EXHIBIT_MATRIX @PROMOTE_NONCORE_TO_CORE "
+            "@FAIL_CLOSED @STRICT ?PIPE=RELIEF>FORM>STANDARD>ELEMENTS>PO>DEADLINES>SERVICE>EXHIBITS"
+            "&OUT=ZIP+MD+CSV+JSON&ITER=auto&STRICT=true"
+        ),
+    },
+]
 
-DEFAULT_CATEGORY = "Other"
-ORGANIZED_FOLDER = "Organized"
 
-# Required drives for litigation system
-REQUIRED_DRIVES = ["Q", "D", "Z"]
-FORBIDDEN_DRIVE = "C"
+@dataclass(frozen=True)
+class Config:
+    sources: list[Path]
+    dest_root: Path
+    move_mode: bool
+    dedupe: bool
+    dedupe_action: str
+    skip_reparse: bool
+    compute_sha256: bool
+    exclude_roots: list[Path]
+    self_test: bool
+    self_test_runs: int
+    self_test_only: bool
+    remove_empty_dirs: bool
+    catalog_db: Path | None
+    mermaid_path: Path | None
+    erd_path: Path | None
+    esd_path: Path | None
+    forensic_path: Path | None
+    stratus_path: Path | None
+    graph_output_dir: Path | None
+    logs_dir: Path
+    run_manifest_path: Path | None
 
 
-def get_drive_letter(path: Path) -> str | None:
-    """Extract the drive letter from a path on Windows.
-    
-    Returns the uppercase drive letter without colon, or None if not a Windows drive path.
-    """
-    if platform.system() != "Windows":
-        return None
-    
-    # Resolve to handle symbolic links and junctions
+@dataclass
+class Counts:
+    copied: int = 0
+    moved: int = 0
+    dup_skipped: int = 0
+    dup_quarantined: int = 0
+    failed: int = 0
+    source_missing: int = 0
+
+
+@dataclass
+class LogPaths:
+    csv_log: Path
+    jsonl_log: Path
+    index_csv: Path
+
+
+@dataclass
+class RunState:
+    counts: Counts = field(default_factory=Counts)
+    hash_index: dict[str, Path] = field(default_factory=dict)
+    logs: LogPaths | None = None
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_atomic(path: Path, contents: str) -> None:
+    ensure_dir(path.parent)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(contents, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def normalize_root(path: Path) -> Path:
+    resolved = path.resolve()
+    return resolved
+
+
+def build_exclude_list(roots: Iterable[Path]) -> list[Path]:
+    return [normalize_root(root) for root in roots]
+
+
+def is_excluded(path: Path, exclude_roots: Iterable[Path]) -> bool:
     try:
-        resolved_path = path.resolve()
-    except (OSError, RuntimeError):
-        # If resolution fails, use the original path
-        resolved_path = path
-    
-    path_str = str(resolved_path)
-    if len(path_str) >= 2 and path_str[1] == ":":
-        return path_str[0].upper()
-    return None
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    for root in exclude_roots:
+        try:
+            if resolved == root or root in resolved.parents:
+                return True
+        except RuntimeError:
+            if str(resolved).lower().startswith(str(root).lower()):
+                return True
+    return False
 
 
-def validate_drive_path(path: Path, required_drives: list[str] = None) -> tuple[bool, str]:
-    """Validate that a path meets drive requirements for the litigation system.
-    
-    Args:
-        path: The path to validate
-        required_drives: List of required drive letters (defaults to REQUIRED_DRIVES)
-        
-    Returns:
-        tuple: (is_valid, error_message)
-               is_valid is True if validation passes, False otherwise
-               error_message describes the validation failure, or empty string on success
-    """
-    if required_drives is None:
-        required_drives = REQUIRED_DRIVES
-    
-    # Check if path exists
-    if not path.exists():
-        return False, f"Path does not exist: {path}"
-    
-    # For non-Windows systems, skip drive validation
-    if platform.system() != "Windows":
-        return True, ""
-    
-    # Get the drive letter (this also resolves symlinks/junctions)
-    drive_letter = get_drive_letter(path)
-    
-    if drive_letter is None:
-        return False, f"Could not determine drive letter for path: {path}"
-    
-    # Check if it's the forbidden C: drive
-    if drive_letter == FORBIDDEN_DRIVE:
-        return False, f"C: drive is forbidden for litigation data. Path resolves to: {path.resolve()}"
-    
-    # Check if it's one of the required drives
-    if drive_letter not in required_drives:
-        return False, f"Drive {drive_letter}: is not one of the required drives: {', '.join(required_drives)}"
-    
-    return True, ""
+def get_ext_bucket(path: Path) -> str:
+    ext = path.suffix.lower().lstrip(".")
+    return ext if ext else "_no_extension"
 
 
-def check_required_drives_exist(required_drives: list[str] = None) -> tuple[bool, list[str]]:
-    """Check if all required drives are present on the system.
-    
-    Args:
-        required_drives: List of required drive letters (defaults to REQUIRED_DRIVES)
-        
-    Returns:
-        tuple: (all_present, missing_drives)
-               all_present is True if all drives exist, False otherwise
-               missing_drives is a list of drive letters that are missing
-    """
-    if required_drives is None:
-        required_drives = REQUIRED_DRIVES
-    
-    # Skip check on non-Windows systems
-    if platform.system() != "Windows":
-        return True, []
-    
-    missing = []
-    for drive in required_drives:
-        drive_path = Path(f"{drive}:/")
-        if not drive_path.exists():
-            missing.append(drive)
-    
-    return len(missing) == 0, missing
+def get_string_md5(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8")).hexdigest()
 
 
-def get_category(file_path: Path) -> str:
-    ext = file_path.suffix.lower()
-    for category, extensions in CATEGORIES.items():
-        if ext in extensions:
-            return category
-    return DEFAULT_CATEGORY
+def get_file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
 
 
-def safe_move(src: Path, dest: Path) -> None:
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    if dest.exists():
-        base = dest.stem
-        suffix = dest.suffix
-        counter = 1
-        while True:
-            new_name = f"{base}_{counter}{suffix}"
-            new_dest = dest.with_name(new_name)
-            if not new_dest.exists():
-                dest = new_dest
-                break
-            counter += 1
-    shutil.move(str(src), str(dest))
+def unique_dest_name(path: Path, src_leaf: str) -> str:
+    path_hash = get_string_md5(str(path))[:10]
+    return f"{src_leaf}__{path_hash}__{path.name}"
 
 
-def move_file(base_output: Path, file_path: Path) -> None:
+def copy_or_move(src: Path, dst: Path, move_mode: bool) -> bool:
     try:
-        category = get_category(file_path)
-        dest_dir = base_output / category
-        destination = dest_dir / file_path.name
-        safe_move(file_path, destination)
-        logging.info("Moved %s -> %s", file_path, destination)
-    except Exception as e:
-        logging.error("Failed to move %s: %s", file_path, e)
+        ensure_dir(dst.parent)
+        if move_mode:
+            shutil.move(str(src), str(dst))
+        else:
+            shutil.copy2(str(src), str(dst))
+        return True
+    except OSError:
+        return False
 
 
-def remove_empty_dirs(base_path: Path) -> None:
-    for dirpath, dirnames, filenames in os.walk(base_path, topdown=False):
-        p = Path(dirpath)
-        if not list(p.glob("*")):
-            try:
-                p.rmdir()
-                logging.info("Removed empty directory %s", p)
-            except Exception as e:
-                logging.error("Failed to remove %s: %s", p, e)
-
-
-def organize_drive(target_path: Path, output_path: Path | None = None) -> None:
-    base_output = output_path.resolve() if output_path else target_path / ORGANIZED_FOLDER
-    base_output.mkdir(exist_ok=True)
-
-    files_to_move = []
-    for root, dirs, files in os.walk(target_path):
-        # Skip the output directory itself
-        if ORGANIZED_FOLDER in Path(root).parts:
+def get_files_safe(
+    root: Path, skip_reparse: bool, exclude_roots: Iterable[Path]
+) -> Iterator[Path]:
+    if is_excluded(root, exclude_roots):
+        return
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    entry_path = Path(entry.path)
+                    if is_excluded(entry_path, exclude_roots):
+                        continue
+                    if skip_reparse and entry.is_symlink():
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry_path)
+                    elif entry.is_file(follow_symlinks=False):
+                        yield entry_path
+        except (OSError, PermissionError):
             continue
-        for file in files:
-            files_to_move.append(Path(root) / file)
-
-    with ThreadPoolExecutor(max_workers=os.cpu_count() or 4) as executor:
-        for f in tqdm(files_to_move, desc="Organizing", unit="file"):
-            executor.submit(move_file, base_output, f)
-
-    remove_empty_dirs(target_path)
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Organize files on a drive")
-    parser.add_argument("path", nargs="?", default="F:/", help="Path to organize (default F:/)")
-    parser.add_argument("--log", default="organize_drive.log", help="Log file path")
-    parser.add_argument("--output", default=None, help="Optional output directory")
+def write_row_csv(path: Path, row: dict[str, object]) -> None:
+    ensure_dir(path.parent)
+    file_exists = path.exists()
+    with path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(row.keys()))
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def write_row_jsonl(path: Path, row: dict[str, object]) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+
+def init_catalog(path: Path) -> None:
+    ensure_dir(path.parent)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS catalog (
+                id INTEGER PRIMARY KEY,
+                time_utc TEXT NOT NULL,
+                action TEXT NOT NULL,
+                source_root TEXT,
+                source TEXT,
+                dest TEXT,
+                ext TEXT,
+                bytes INTEGER,
+                sha256 TEXT,
+                note TEXT,
+                error TEXT
+            )
+            """
+        )
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+
+
+def catalog_row(path: Path, row: dict[str, object]) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            INSERT INTO catalog
+            (time_utc, action, source_root, source, dest, ext, bytes, sha256, note, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row.get("time_utc"),
+                row.get("action"),
+                row.get("source_root"),
+                row.get("source"),
+                row.get("dest"),
+                row.get("ext"),
+                row.get("bytes"),
+                row.get("sha256"),
+                row.get("note"),
+                row.get("error"),
+            ),
+        )
+
+
+def record_event(row: dict[str, object], state: RunState, catalog_db: Path | None) -> None:
+    if state.logs is None:
+        raise RuntimeError("Logs not initialized")
+    write_row_csv(state.logs.csv_log, row)
+    write_row_jsonl(state.logs.jsonl_log, row)
+    if catalog_db:
+        catalog_row(catalog_db, row)
+
+
+def generate_mermaid(path: Path, config: Config, state: RunState) -> None:
+    contents = [
+        "flowchart TD",
+        "  A[Harvest: Scan Files] --> B[Deduplicate + Hash]",
+        "  B --> C[Bucket by Extension]",
+        "  C --> D[Copy/Move]",
+        "  D --> E[Index + Logs]",
+        "  E --> F[Catalog (SQLite ACID)]",
+        "  E --> G[Duplicate Quarantine]",
+        f"  F --> H[Summary: copied={state.counts.copied} moved={state.counts.moved}]",
+        f"  H --> I[Destination: {config.dest_root.as_posix()}]",
+        f"  I --> J[Mode: {'MOVE' if config.move_mode else 'COPY'}]",
+        f"  J --> K[Dedupe: {config.dedupe_action if config.dedupe else 'OFF'}]",
+    ]
+    write_atomic(path, "\n".join(contents) + "\n")
+
+
+def generate_erd_blueprint(path: Path) -> None:
+    contents = [
+        "erDiagram",
+        "  RUN ||--o{ CATALOG_EVENT : records",
+        "  RUN ||--o{ EXT_BUCKET : aggregates",
+        "  RUN ||--o{ RUN_LOG : logs",
+        "  RUN {",
+        "    string time_utc",
+        "    string dest_root",
+        "    string logs_dir",
+        "    string mode_react",
+        "    string mode_reflexion",
+        "  }",
+        "  RUN_LOG {",
+        "    string time_utc",
+        "    string csv_log",
+        "    string jsonl_log",
+        "    string index_csv",
+        "  }",
+        "  CATALOG_EVENT {",
+        "    string time_utc",
+        "    string action",
+        "    string source_root",
+        "    string source",
+        "    string dest",
+        "    string ext",
+        "    int bytes",
+        "    string sha256",
+        "    string note",
+        "    string error",
+        "  }",
+        "  EXT_BUCKET {",
+        "    string ext_bucket",
+        "    int file_count",
+        "    int total_bytes",
+        "    string folder",
+        "  }",
+    ]
+    write_atomic(path, "\n".join(contents) + "\n")
+
+
+def generate_esd_blueprint(path: Path) -> None:
+    contents = [
+        "flowchart TD",
+        "  ROOT[ESD Blueprint: Unified Attachments + Evidence]",
+        "  ROOT --> L0[Blueprint Stack]",
+        "  ROOT --> ERD[Core ERD / Spine]",
+        "  ROOT --> AUTH[Authority ERD]",
+        "  ROOT --> AUTO[Automation ERD]",
+        "  ROOT --> EVID[Evidence ERD]",
+        "  ROOT --> INTEROP[Interop ERD]",
+        "  L0 --> L1[L0 Storage Eligibility + Roots]",
+        "  L1 --> L2[L1 Intake + Delta Harvest]",
+        "  L2 --> L3[L2 EvidenceAtoms + Provenance]",
+        "  L3 --> L4[L3 ChronoDB + QuoteDB]",
+        "  L4 --> L5[L4 AuthoritySnapshot + Vehicles]",
+        "  L5 --> L6[L5 Contracts (C2→C3)]",
+        "  L6 --> L7[L6 Scoring + Gates]",
+        "  L7 --> L8[L7 Actions + Automation]",
+        "  L8 --> L9[L8 Packaging + Filing Packs]",
+        "  ERD --> ERD1[Run → Artifact → Evidence/Authority]",
+        "  ERD --> ERD2[Vehicle → Proof Obligation → Gate Result]",
+        "  AUTH --> AUTH1[Proposition ⇄ AuthoritySnapshot]",
+        "  AUTH --> AUTH2[VehiclePropositionLink]",
+        "  AUTO --> AUTO1[Run → RunStep → RunEvent]",
+        "  AUTO --> AUTO2[Schedule/Task → Agent]",
+        "  EVID --> EVID1[EvidenceAtom ⇄ EvidenceItem]",
+        "  EVID --> EVID2[Exhibit ⇄ EvidenceItemExhibitLink]",
+        "  INTEROP --> INT1[BagitManifest + CloudEvent]",
+        "  INTEROP --> INT2[OpenLineageRun + OTEL Span/Metric]",
+        "  INTEROP --> INT3[Provenance Entity/Relation]",
+        "  INTEROP --> INT4[SLSA Provenance]",
+        "  INTEROP --> INT5[Catalog Events + Log Index]",
+        "  EVID --> EVID3[Duplicate Quarantine Store]",
+        "  EVID --> EVID4[Extension Buckets]",
+    ]
+    write_atomic(path, "\n".join(contents) + "\n")
+
+
+def generate_forensic_inventory(path: Path, state: RunState) -> None:
+    inventory = {
+        "generated_utc": utc_now_iso(),
+        "counts": {
+            "copied": state.counts.copied,
+            "moved": state.counts.moved,
+            "dup_skipped": state.counts.dup_skipped,
+            "dup_quarantined": state.counts.dup_quarantined,
+            "failed": state.counts.failed,
+            "source_missing": state.counts.source_missing,
+        },
+        "logs": {
+            "csv": str(state.logs.csv_log) if state.logs else None,
+            "jsonl": str(state.logs.jsonl_log) if state.logs else None,
+            "index": str(state.logs.index_csv) if state.logs else None,
+        },
+    }
+    write_atomic(path, json.dumps(inventory, indent=2) + "\n")
+
+
+def generate_run_manifest(path: Path, config: Config, state: RunState) -> None:
+    manifest = {
+        "generated_utc": utc_now_iso(),
+        "sources": [str(src) for src in config.sources],
+        "destination": str(config.dest_root),
+        "move_mode": config.move_mode,
+        "dedupe": config.dedupe,
+        "dedupe_action": config.dedupe_action if config.dedupe else "OFF",
+        "remove_empty_dirs": config.remove_empty_dirs,
+        "exclude_roots": [str(root) for root in config.exclude_roots],
+        "logs": {
+            "csv": str(state.logs.csv_log) if state.logs else None,
+            "jsonl": str(state.logs.jsonl_log) if state.logs else None,
+            "index": str(state.logs.index_csv) if state.logs else None,
+        },
+        "counts": {
+            "copied": state.counts.copied,
+            "moved": state.counts.moved,
+            "dup_skipped": state.counts.dup_skipped,
+            "dup_quarantined": state.counts.dup_quarantined,
+            "failed": state.counts.failed,
+            "source_missing": state.counts.source_missing,
+        },
+        "strategy_options": STRATEGY_OPTIONS,
+    }
+    write_atomic(path, json.dumps(manifest, indent=2) + "\n")
+
+
+def generate_stratus_overview(path: Path) -> None:
+    contents = [
+        "flowchart TD",
+        "  STRATUS[Stratus Overview]",
+        "  STRATUS --> CELL[Per-Cell Tranche Inventory]",
+        "  STRATUS --> LATTICE[Kosahedron Plane Lattice Torus Overlay]",
+        "  CELL --> C1[Cell: L0 Storage]",
+        "  CELL --> C2[Cell: L1 Intake]",
+        "  CELL --> C3[Cell: L2 EvidenceAtoms]",
+        "  CELL --> C4[Cell: L3 Chrono/Quote]",
+        "  CELL --> C5[Cell: L4 Authority/Vehicles]",
+        "  CELL --> C6[Cell: L5 Contracts]",
+        "  CELL --> C7[Cell: L6 Scoring/Gates]",
+        "  CELL --> C8[Cell: L7 Actions]",
+        "  CELL --> C9[Cell: L8 Packaging]",
+        "  LATTICE --> L1[Kosahedron Plane]",
+        "  LATTICE --> L2[Lattice Mesh]",
+        "  LATTICE --> L3[Torus Tranche Overlay]",
+    ]
+    write_atomic(path, "\n".join(contents) + "\n")
+
+
+def load_index_rows(index_csv: Path | None) -> list[dict[str, str]]:
+    if not index_csv or not index_csv.exists():
+        return []
+    with index_csv.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [row for row in reader]
+
+
+def build_graph_payload(index_rows: list[dict[str, str]], config: Config) -> dict[str, object]:
+    nodes: list[dict[str, object]] = []
+    edges: list[dict[str, object]] = []
+
+    root_id = "run_root"
+    nodes.append(
+        {
+            "data": {
+                "id": root_id,
+                "label": f"Run: {config.dest_root}",
+                "type": "run",
+            }
+        }
+    )
+
+    logs_id = "run_logs"
+    nodes.append(
+        {
+            "data": {
+                "id": logs_id,
+                "label": "Logs + Index",
+                "type": "log",
+            }
+        }
+    )
+    edges.append(
+        {
+            "data": {
+                "id": f"edge::{root_id}::{logs_id}",
+                "source": root_id,
+                "target": logs_id,
+                "label": "emits",
+            }
+        }
+    )
+
+    if config.dedupe and config.dedupe_action == "Quarantine":
+        dup_id = "dup_quarantine"
+        nodes.append(
+            {
+                "data": {
+                    "id": dup_id,
+                    "label": "Duplicates Quarantine",
+                    "type": "duplicate",
+                }
+            }
+        )
+        edges.append(
+            {
+                "data": {
+                    "id": f"edge::{root_id}::{dup_id}",
+                    "source": root_id,
+                    "target": dup_id,
+                    "label": "quarantines",
+                }
+            }
+        )
+
+    if config.catalog_db:
+        catalog_id = "catalog_db"
+        nodes.append(
+            {
+                "data": {
+                    "id": catalog_id,
+                    "label": "SQLite Catalog",
+                    "type": "catalog",
+                }
+            }
+        )
+        edges.append(
+            {
+                "data": {
+                    "id": f"edge::{root_id}::{catalog_id}",
+                    "source": root_id,
+                    "target": catalog_id,
+                    "label": "records",
+                }
+            }
+        )
+
+    for row in index_rows:
+        ext_bucket = row.get("ext_bucket", "_unknown")
+        node_id = f"ext::{ext_bucket}"
+        nodes.append(
+            {
+                "data": {
+                    "id": node_id,
+                    "label": f"{ext_bucket} ({row.get('file_count', '0')})",
+                    "type": "extension",
+                    "file_count": row.get("file_count", "0"),
+                    "total_bytes": row.get("total_bytes", "0"),
+                    "folder": row.get("folder", ""),
+                }
+            }
+        )
+        edges.append(
+            {
+                "data": {
+                    "id": f"edge::{root_id}::{node_id}",
+                    "source": root_id,
+                    "target": node_id,
+                    "label": "contains",
+                }
+            }
+        )
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def write_graph_exports(output_dir: Path, payload: dict[str, object]) -> None:
+    ensure_dir(output_dir)
+    graph_json = json.dumps(payload, indent=2)
+    write_atomic(output_dir / "graph.json", graph_json + "\n")
+
+    nodes = payload.get("nodes", [])
+    edges = payload.get("edges", [])
+    html = f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Executive Suite Graph</title>
+    <style>
+      body {{ margin: 0; font-family: Arial, sans-serif; }}
+      #cy {{ width: 100vw; height: 100vh; }}
+      .panel {{
+        position: absolute; top: 12px; left: 12px; z-index: 10;
+        background: rgba(255,255,255,0.9); padding: 10px; border-radius: 6px;
+      }}
+      #fallback {{
+        position: absolute; top: 80px; left: 12px; z-index: 10;
+        background: rgba(255,255,255,0.95); padding: 10px; border-radius: 6px;
+        max-width: 420px; display: none;
+      }}
+    </style>
+    <script src="https://unpkg.com/cytoscape@3.27.0/dist/cytoscape.min.js"></script>
+  </head>
+  <body>
+    <div class="panel">
+      <strong>Executive Suite Graph</strong>
+      <div>Interactive nodes + zoom + pan</div>
+    </div>
+    <div id="fallback">
+      <strong>Offline fallback</strong>
+      <div>Cytoscape CDN unavailable. See graph.json for full data.</div>
+      <pre id="fallback-json"></pre>
+    </div>
+    <div id="cy"></div>
+    <script>
+      const elements = {{"nodes": {json.dumps(nodes)}, "edges": {json.dumps(edges)}}};
+      if (typeof cytoscape === "function") {{
+        const cy = cytoscape({{
+          container: document.getElementById("cy"),
+          elements,
+          layout: {{ name: "cose" }},
+          style: [
+            {{ selector: "node", style: {{ "label": "data(label)", "background-color": "#4b8bbe", "color": "#111", "text-outline-width": 1, "text-outline-color": "#fff" }} }},
+            {{ selector: "edge", style: {{ "width": 1.5, "line-color": "#999", "target-arrow-shape": "triangle", "target-arrow-color": "#999" }} }},
+            {{ selector: "node[type = 'run']", style: {{ "background-color": "#6c5ce7", "shape": "round-rectangle" }} }},
+            {{ selector: "node[type = 'log']", style: {{ "background-color": "#00b894", "shape": "diamond" }} }},
+            {{ selector: "node[type = 'duplicate']", style: {{ "background-color": "#fdcb6e", "shape": "hexagon" }} }},
+            {{ selector: "node[type = 'catalog']", style: {{ "background-color": "#e17055", "shape": "ellipse" }} }}
+          ]
+        }});
+      }} else {{
+        const fallback = document.getElementById("fallback");
+        const fallbackJson = document.getElementById("fallback-json");
+        fallback.style.display = "block";
+        fallbackJson.textContent = JSON.stringify(elements, null, 2);
+      }}
+    </script>
+  </body>
+</html>
+"""
+    write_atomic(output_dir / "graph.html", html)
+
+    node_rows = ["id,label,type,file_count,total_bytes,folder"]
+    for node in nodes:
+        data = node.get("data", {})
+        node_rows.append(
+            ",".join(
+                [
+                    str(data.get("id", "")),
+                    str(data.get("label", "")),
+                    str(data.get("type", "")),
+                    str(data.get("file_count", "")),
+                    str(data.get("total_bytes", "")),
+                    str(data.get("folder", "")),
+                ]
+            )
+        )
+    write_atomic(output_dir / "neo4j_nodes.csv", "\n".join(node_rows) + "\n")
+
+    edge_rows = ["id,source,target,label"]
+    for edge in edges:
+        data = edge.get("data", {})
+        edge_rows.append(
+            ",".join(
+                [
+                    str(data.get("id", "")),
+                    str(data.get("source", "")),
+                    str(data.get("target", "")),
+                    str(data.get("label", "")),
+                ]
+            )
+        )
+    write_atomic(output_dir / "neo4j_edges.csv", "\n".join(edge_rows) + "\n")
+
+
+def index_by_extension(dest_root: Path, logs_dir: Path) -> Path:
+    ensure_dir(logs_dir)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    index_path = logs_dir / f"index_by_ext_{ts}.csv"
+    rows: list[dict[str, object]] = []
+    for child in dest_root.iterdir():
+        if not child.is_dir():
+            continue
+        if child.name in {"__LOGS", "__DUPLICATES"}:
+            continue
+        total_bytes = 0
+        file_count = 0
+        for file_path in child.rglob("*"):
+            if file_path.is_file():
+                try:
+                    total_bytes += file_path.stat().st_size
+                except OSError:
+                    continue
+                file_count += 1
+        rows.append(
+            {
+                "ext_bucket": child.name,
+                "file_count": file_count,
+                "total_bytes": total_bytes,
+                "folder": str(child),
+            }
+        )
+    rows.sort(key=lambda row: row["file_count"], reverse=True)
+    if rows:
+        with index_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+    else:
+        index_path.write_text("ext_bucket,file_count,total_bytes,folder\n", encoding="utf-8")
+    return index_path
+
+
+def prepare_logs(dest_root: Path, logs_dir: Path) -> LogPaths:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    csv_log = logs_dir / f"organize_by_ext_{ts}.csv"
+    jsonl_log = logs_dir / f"organize_by_ext_{ts}.jsonl"
+    index_csv = logs_dir / f"index_by_ext_{ts}.csv"
+    ensure_dir(logs_dir)
+    return LogPaths(csv_log=csv_log, jsonl_log=jsonl_log, index_csv=index_csv)
+
+
+def organize_by_extension(config: Config, state: RunState) -> None:
+    logs = prepare_logs(config.dest_root, config.logs_dir)
+    state.logs = logs
+    if config.catalog_db:
+        init_catalog(config.catalog_db)
+
+    duplicates_root = config.dest_root / "__DUPLICATES"
+    ensure_dir(config.dest_root)
+    ensure_dir(config.logs_dir)
+    if config.dedupe and config.dedupe_action == "Quarantine":
+        ensure_dir(duplicates_root)
+
+    for src_root in config.sources:
+        if not src_root.exists():
+            state.counts.source_missing += 1
+            row = {
+                "time_utc": utc_now_iso(),
+                "action": "SOURCE_MISSING",
+                "source_root": str(src_root),
+                "source": None,
+                "dest": None,
+                "ext": None,
+                "bytes": None,
+                "sha256": None,
+                "note": None,
+                "error": None,
+            }
+            record_event(row, state, config.catalog_db)
+            continue
+
+        src_leaf = src_root.name or "source"
+        for file_path in get_files_safe(src_root, config.skip_reparse, config.exclude_roots):
+            ext_bucket = get_ext_bucket(file_path)
+            ext_dir = config.dest_root / ext_bucket
+            dest_name = unique_dest_name(file_path, src_leaf)
+            dest_path = ext_dir / dest_name
+
+            sha = None
+            if config.compute_sha256 or config.dedupe:
+                try:
+                    sha = get_file_sha256(file_path)
+                except OSError:
+                    sha = None
+
+            if config.dedupe and sha and sha in state.hash_index:
+                if config.dedupe_action == "Skip":
+                    state.counts.dup_skipped += 1
+                    row = {
+                        "time_utc": utc_now_iso(),
+                        "action": "DUPLICATE_SKIPPED",
+                        "source_root": str(src_root),
+                        "source": str(file_path),
+                        "dest": None,
+                        "ext": ext_bucket,
+                        "bytes": safe_stat_size(file_path),
+                        "sha256": sha,
+                        "note": f"primary={state.hash_index[sha]}",
+                        "error": None,
+                    }
+                    record_event(row, state, config.catalog_db)
+                    continue
+                if config.dedupe_action == "Quarantine":
+                    q_dir = duplicates_root / ext_bucket
+                    q_path = q_dir / dest_name
+                    ok = copy_or_move(file_path, q_path, config.move_mode)
+                    if ok:
+                        state.counts.dup_quarantined += 1
+                        row = {
+                            "time_utc": utc_now_iso(),
+                            "action": "DUPLICATE_MOVED_TO_QUARANTINE"
+                            if config.move_mode
+                            else "DUPLICATE_COPIED_TO_QUARANTINE",
+                            "source_root": str(src_root),
+                            "source": str(file_path),
+                            "dest": str(q_path),
+                            "ext": ext_bucket,
+                            "bytes": safe_stat_size(file_path),
+                            "sha256": sha,
+                            "note": f"primary={state.hash_index[sha]}",
+                            "error": None,
+                        }
+                        record_event(row, state, config.catalog_db)
+                        continue
+                    state.counts.failed += 1
+                    row = {
+                        "time_utc": utc_now_iso(),
+                        "action": "FAILED_DUP_QUARANTINE",
+                        "source_root": str(src_root),
+                        "source": str(file_path),
+                        "dest": str(q_path),
+                        "ext": ext_bucket,
+                        "bytes": safe_stat_size(file_path),
+                        "sha256": sha,
+                        "note": f"primary={state.hash_index[sha]}",
+                        "error": "copy_or_move failed",
+                    }
+                    record_event(row, state, config.catalog_db)
+                    continue
+
+            ok = copy_or_move(file_path, dest_path, config.move_mode)
+            if ok:
+                if config.move_mode:
+                    state.counts.moved += 1
+                else:
+                    state.counts.copied += 1
+                if config.dedupe and sha and sha not in state.hash_index:
+                    state.hash_index[sha] = dest_path
+                row = {
+                    "time_utc": utc_now_iso(),
+                    "action": "MOVED" if config.move_mode else "COPIED",
+                    "source_root": str(src_root),
+                    "source": str(file_path),
+                    "dest": str(dest_path),
+                    "ext": ext_bucket,
+                    "bytes": safe_stat_size(file_path),
+                    "sha256": sha,
+                    "note": None,
+                    "error": None,
+                }
+                record_event(row, state, config.catalog_db)
+            else:
+                state.counts.failed += 1
+                row = {
+                    "time_utc": utc_now_iso(),
+                    "action": "FAILED",
+                    "source_root": str(src_root),
+                    "source": str(file_path),
+                    "dest": str(dest_path),
+                    "ext": ext_bucket,
+                    "bytes": safe_stat_size(file_path),
+                    "sha256": sha,
+                    "note": None,
+                    "error": "copy_or_move failed",
+                }
+                record_event(row, state, config.catalog_db)
+
+    state.logs.index_csv = index_by_extension(config.dest_root, config.logs_dir)
+
+
+def safe_stat_size(path: Path) -> int | None:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+def remove_empty_dirs(roots: Iterable[Path], exclude_roots: Iterable[Path]) -> None:
+    for root in roots:
+        if not root.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+            current = Path(dirpath)
+            if is_excluded(current, exclude_roots):
+                continue
+            try:
+                if not any(Path(dirpath).iterdir()):
+                    current.rmdir()
+            except OSError:
+                continue
+
+
+def run_self_test() -> None:
+    base = Path(os.getenv("TEMP", "/tmp")) / f"OrgByExt_SelfTest_{int(time.time())}"
+    src1 = base / "src1"
+    src2 = base / "src2"
+    dst = base / "dst"
+    ensure_dir(src1 / "nested")
+    ensure_dir(src2 / "nested")
+    ensure_dir(dst)
+
+    (src1 / "a.txt").write_text("same-content", encoding="utf-8")
+    (src2 / "b.txt").write_text("same-content", encoding="utf-8")
+    (src1 / "c.pdf").write_text("pdf-content", encoding="utf-8")
+    (src2 / "d").write_text("noext", encoding="utf-8")
+    (src1 / "nested" / "e.jpg").write_text("img", encoding="utf-8")
+    (src2 / "nested" / "f.jpg").write_text("img2", encoding="utf-8")
+
+    mermaid_path = base / "mermaid.mmd"
+    erd_path = base / "erd.mmd"
+    esd_path = base / "esd.mmd"
+    forensic_path = base / "forensic.json"
+    stratus_path = base / "stratus.mmd"
+    catalog_db = base / "catalog.sqlite"
+    graph_output_dir = base / "graph"
+    run_manifest_path = base / "run_manifest.json"
+
+    config = Config(
+        sources=[src1, src2],
+        dest_root=dst,
+        move_mode=False,
+        dedupe=True,
+        dedupe_action="Quarantine",
+        skip_reparse=True,
+        compute_sha256=True,
+        exclude_roots=[],
+        self_test=False,
+        self_test_runs=1,
+        self_test_only=False,
+        remove_empty_dirs=False,
+        catalog_db=catalog_db,
+        mermaid_path=mermaid_path,
+        erd_path=erd_path,
+        esd_path=esd_path,
+        forensic_path=forensic_path,
+        stratus_path=stratus_path,
+        graph_output_dir=graph_output_dir,
+        logs_dir=dst / "__LOGS",
+        run_manifest_path=run_manifest_path,
+    )
+    state = RunState()
+    organize_by_extension(config, state)
+    generate_mermaid(config.mermaid_path, config, state)
+    generate_erd_blueprint(config.erd_path)
+    generate_esd_blueprint(config.esd_path)
+    generate_forensic_inventory(config.forensic_path, state)
+    generate_stratus_overview(config.stratus_path)
+    generate_run_manifest(config.run_manifest_path, config, state)
+    if config.graph_output_dir:
+        index_rows = load_index_rows(state.logs.index_csv if state.logs else None)
+        graph_payload = build_graph_payload(index_rows, config)
+        write_graph_exports(config.graph_output_dir, graph_payload)
+
+    assert (dst / "txt").exists(), "SelfTest: missing txt folder"
+    assert (dst / "pdf").exists(), "SelfTest: missing pdf folder"
+    assert (dst / "jpg").exists(), "SelfTest: missing jpg folder"
+    assert (dst / "_no_extension").exists(), "SelfTest: missing _no_extension folder"
+    assert (dst / "__DUPLICATES" / "txt").exists(), "SelfTest: missing dup quarantine txt folder"
+    assert mermaid_path.exists(), "SelfTest: missing mermaid output"
+    assert erd_path.exists(), "SelfTest: missing ERD output"
+    assert esd_path.exists(), "SelfTest: missing ESD output"
+    assert forensic_path.exists(), "SelfTest: missing forensic output"
+    assert stratus_path.exists(), "SelfTest: missing stratus output"
+    assert graph_output_dir.joinpath("graph.json").exists(), "SelfTest: missing graph.json"
+    assert graph_output_dir.joinpath("graph.html").exists(), "SelfTest: missing graph.html"
+    assert run_manifest_path.exists(), "SelfTest: missing run manifest"
+    primary_txt = list((dst / "txt").glob("*"))
+    dup_txt = list((dst / "__DUPLICATES" / "txt").glob("*"))
+    assert len(primary_txt) == 1, "SelfTest: expected 1 primary txt file"
+    assert len(dup_txt) == 1, "SelfTest: expected 1 quarantined dup txt file"
+    shutil.rmtree(base, ignore_errors=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "High-signal extension organizer with ACID catalog, dedupe, quarantine, "
+            "and mermaid lakehouse graph outputs."
+        )
+    )
+    parser.add_argument("--sources", nargs="+", required=True, help="Source roots to scan")
+    parser.add_argument("--dest-root", required=True, help="Destination root")
+    parser.add_argument("--move", action="store_true", help="Move files instead of copying")
+    parser.add_argument(
+        "--dedupe-action",
+        choices=["Quarantine", "Skip", "KeepAll"],
+        default="Quarantine",
+        help="Duplicate handling mode",
+    )
+    parser.add_argument(
+        "--no-dedupe", action="store_true", help="Disable SHA-256 deduplication"
+    )
+    parser.add_argument(
+        "--skip-reparse",
+        action="store_true",
+        help="Skip symlinks and reparse points",
+    )
+    parser.add_argument(
+        "--no-sha256", action="store_true", help="Disable SHA-256 computation"
+    )
+    parser.add_argument(
+        "--exclude-root",
+        action="append",
+        default=[],
+        help="Exclude root (repeatable)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run self-test before processing sources",
+    )
+    parser.add_argument(
+        "--self-test-runs",
+        type=int,
+        default=1,
+        help="Number of self-test runs (default: 1)",
+    )
+    parser.add_argument(
+        "--self-test-only",
+        action="store_true",
+        help="Exit after completing self-test runs",
+    )
+    parser.add_argument(
+        "--remove-empty-dirs",
+        action="store_true",
+        help="Remove empty source folders after move mode",
+    )
+    parser.add_argument(
+        "--catalog-db",
+        default=None,
+        help="Optional SQLite catalog path (ACID)",
+    )
+    parser.add_argument(
+        "--mermaid",
+        default=None,
+        help="Optional path to write mermaid flowchart",
+    )
+    parser.add_argument(
+        "--erd-blueprint",
+        default=None,
+        help="Optional path to write ERD-style blueprint",
+    )
+    parser.add_argument(
+        "--esd-blueprint",
+        default=None,
+        help="Optional path to write unified ESD-style blueprint",
+    )
+    parser.add_argument(
+        "--forensic-inventory",
+        default=None,
+        help="Optional path to write forensic inventory JSON",
+    )
+    parser.add_argument(
+        "--stratus-overview",
+        default=None,
+        help="Optional path to write stratus overview mermaid",
+    )
+    parser.add_argument(
+        "--graph-output-dir",
+        default=None,
+        help="Optional directory to write graph artifacts (json/html/csv)",
+    )
+    parser.add_argument(
+        "--logs-dir",
+        default="__LOGS",
+        help="Directory name for logs (inside dest root)",
+    )
+    parser.add_argument(
+        "--run-manifest",
+        default=None,
+        help="Optional path to write run manifest JSON",
+    )
+    parser.add_argument("--version", action="version", version=VERSION)
     return parser.parse_args()
 
 
-def main():
-    args = parse_args()
-    logging.basicConfig(
-        filename=args.log,
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s: %(message)s",
+def build_config(args: argparse.Namespace) -> Config:
+    sources = [Path(item).expanduser() for item in args.sources]
+    dest_root = Path(args.dest_root).expanduser()
+    exclude_roots = [Path(item).expanduser() for item in args.exclude_root]
+    logs_dir = dest_root / args.logs_dir
+    return Config(
+        sources=sources,
+        dest_root=dest_root,
+        move_mode=args.move,
+        dedupe=not args.no_dedupe,
+        dedupe_action=args.dedupe_action,
+        skip_reparse=args.skip_reparse,
+        compute_sha256=not args.no_sha256,
+        exclude_roots=build_exclude_list(exclude_roots),
+        self_test=args.self_test,
+        self_test_runs=args.self_test_runs,
+        self_test_only=args.self_test_only,
+        remove_empty_dirs=args.remove_empty_dirs,
+        catalog_db=Path(args.catalog_db).expanduser() if args.catalog_db else None,
+        mermaid_path=Path(args.mermaid).expanduser() if args.mermaid else None,
+        erd_path=Path(args.erd_blueprint).expanduser()
+        if args.erd_blueprint
+        else None,
+        esd_path=Path(args.esd_blueprint).expanduser()
+        if args.esd_blueprint
+        else None,
+        forensic_path=Path(args.forensic_inventory).expanduser()
+        if args.forensic_inventory
+        else None,
+        stratus_path=Path(args.stratus_overview).expanduser()
+        if args.stratus_overview
+        else None,
+        graph_output_dir=Path(args.graph_output_dir).expanduser()
+        if args.graph_output_dir
+        else None,
+        logs_dir=logs_dir,
+        run_manifest_path=Path(args.run_manifest).expanduser()
+        if args.run_manifest
+        else None,
     )
-    target_path = Path(args.path)
-    
-    # Validate the path
-    is_valid, error_msg = validate_drive_path(target_path)
-    if not is_valid:
-        print(f"Error: {error_msg}")
-        return 1
-    
-    # Check if required drives exist
-    all_present, missing = check_required_drives_exist()
-    if not all_present:
-        print(f"Warning: Missing required drives: {', '.join(missing)}")
-        # Note: We continue anyway as the target drive is valid
-    
-    output_path = Path(args.output).resolve() if args.output else None
-    organize_drive(target_path, output_path)
-    print("Organization complete.")
+
+
+def validate_config(config: Config) -> None:
+    if config.dedupe_action not in {"Quarantine", "Skip", "KeepAll"}:
+        raise ValueError("Invalid dedupe action")
+    if config.self_test_runs < 1:
+        raise ValueError("self_test_runs must be >= 1")
+    if config.remove_empty_dirs and not config.move_mode:
+        raise ValueError("remove_empty_dirs requires --move")
+
+
+def main() -> int:
+    args = parse_args()
+    config = build_config(args)
+    validate_config(config)
+    if config.self_test:
+        for _ in range(config.self_test_runs):
+            run_self_test()
+        if config.self_test_only:
+            return 0
+
+    state = RunState()
+    organize_by_extension(config, state)
+    if config.remove_empty_dirs:
+        remove_empty_dirs(config.sources, config.exclude_roots)
+
+    if config.mermaid_path:
+        generate_mermaid(config.mermaid_path, config, state)
+    if config.erd_path:
+        generate_erd_blueprint(config.erd_path)
+    if config.esd_path:
+        generate_esd_blueprint(config.esd_path)
+    if config.forensic_path:
+        generate_forensic_inventory(config.forensic_path, state)
+    if config.stratus_path:
+        generate_stratus_overview(config.stratus_path)
+    if config.graph_output_dir:
+        index_rows = load_index_rows(state.logs.index_csv if state.logs else None)
+        graph_payload = build_graph_payload(index_rows, config)
+        write_graph_exports(config.graph_output_dir, graph_payload)
+    if config.run_manifest_path:
+        generate_run_manifest(config.run_manifest_path, config, state)
+
+    summary = {
+        "time_utc": utc_now_iso(),
+        "destination": str(config.dest_root),
+        "index_csv": str(state.logs.index_csv) if state.logs else None,
+        "csv_log": str(state.logs.csv_log) if state.logs else None,
+        "jsonl_log": str(state.logs.jsonl_log) if state.logs else None,
+        "counts": {
+            "copied": state.counts.copied,
+            "moved": state.counts.moved,
+            "dup_skipped": state.counts.dup_skipped,
+            "dup_quarantined": state.counts.dup_quarantined,
+            "failed": state.counts.failed,
+            "source_missing": state.counts.source_missing,
+        },
+    }
+    print(json.dumps(summary, indent=2))
     return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Record high-level strategy presets in every run manifest so downstream automation and reviewers can consume run-level strategy metadata and policy presets. 
- Ensure parity between the Python CLI and the PowerShell organizer by mirroring the same `strategy_options` in both emitted manifests. 
- Improve auditability and observability of the organizer by producing richer artifacts and a self-test harness that validates the presence of critical outputs.

### Description
- Added a `STRATEGY_OPTIONS` constant to `organize_drive.py` and included it in `generate_run_manifest`, and mirrored an equivalent `strategy_options` array in `organize_drive.ps1` so both CLI implementations emit the same presets. 
- Performed a large rework of `organize_drive.py` to introduce dataclass-based `Config`, `Counts`, `RunState`, robust safe-scanning (`get_files_safe`), dedupe/quarantine flows, atomic writes, CSV/JSONL logging, an optional SQLite catalog, and graph/blueprint exports (`mermaid`, `erd`, `esd`, `forensic`, `stratus`, and graph JSON/HTML/CSV). 
- Implemented and wired a self-test harness that creates temporary sample sources, runs the organize flow, and asserts the presence of generated artifacts (including the run manifest) and index outputs.

### Testing
- Ran the Python self-test: `python organize_drive.py --sources /tmp --dest-root /tmp/organize_drive_test --self-test --self-test-runs 2 --self-test-only`, which completed successfully (exit code `0`) and satisfied internal assertions including the new run manifest. 
- The change did not add separate unit test files; the internal self-test serves as the automated validation included in this PR. 
- PowerShell manifest emission was added and mirrored but was not executed as part of automated PS tests in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bdd4b29483228e88b56be4276d64)