### PR TITLE
Enforce branch trigger keywords in codex guardian

### DIFF
--- a/modules/codex_guardian.py
+++ b/modules/codex_guardian.py
@@ -47,7 +47,12 @@ def verify_branch_name(branch: str) -> bool:
         "hotfix",
         "merge",
     ]
-    return any(key in branch for key in triggers)
+    if not any(key in branch for key in triggers):
+        raise ValueError(
+            "Branch name must include a trigger keyword: "
+            f"{', '.join(triggers)}"
+        )
+    return True
 
 
 def verify_manifest_hashes() -> None:


### PR DESCRIPTION
### Motivation
- Ensure branch naming policy is enforced consistently by requiring both the `codex/` prefix and an explicit trigger keyword so non-compliant branches are rejected with a clear error.

### Description
- Updated `modules/codex_guardian.py` to have `verify_branch_name()` raise a `ValueError` with an explicit message listing allowed trigger keywords when no trigger is present, while retaining the existing `codex/` prefix check and returning `True` on success.

### Testing
- No automated tests were run after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b63cbfb883228a46bd92ce01730d)