### PR TITLE
Read OpenAI API key from env and add initializer

### DIFF
--- a/openAIkey.py
+++ b/openAIkey.py
@@ -1,2 +1,16 @@
-# Set your OpenAI API key here
-openai.api_key = "your-openai-api-key-here"
+import os
+
+# Set OPENAI_API_KEY in your environment (e.g., `export OPENAI_API_KEY=...`) before use.
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+def init_openai_api_key() -> None:
+    """Initialize the OpenAI API key from the environment."""
+    if not OPENAI_API_KEY:
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set. Configure the environment variable before "
+            "initializing OpenAI."
+        )
+    import openai
+
+    openai.api_key = OPENAI_API_KEY


### PR DESCRIPTION
### Motivation
- Remove a hardcoded OpenAI key from source and ensure the application reads the API key from the environment so secrets are not stored in code and missing configuration is surfaced clearly.

### Description
- Replace the direct `openai.api_key` assignment with `OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")` and add `init_openai_api_key()` which lazily imports `openai`, sets `openai.api_key`, and raises a clear `RuntimeError` when the environment variable is not set.
- Add a short comment instructing users to set the environment variable (for example, `export OPENAI_API_KEY=...`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b63ba70c83228954edc21dfd69f5)