### PR TITLE
Improve local AI adapter for chat prompts

### DIFF
--- a/src/ai_adapter.py
+++ b/src/ai_adapter.py
@@ -7,20 +7,19 @@ you previously called remote APIs to opt into local models.
 """
 
 from __future__ import annotations
+
+import importlib.util
 import os
-from typing import Optional
+from typing import Any, Mapping, Sequence
 
 AI_BACKEND = os.getenv("AI_BACKEND", "local")
 LOCAL_MODEL = os.getenv("LOCAL_MODEL", "gpt2")
 
-try:
-    if AI_BACKEND == "local":
-        from transformers import pipeline
+if AI_BACKEND == "local" and importlib.util.find_spec("transformers"):
+    from transformers import pipeline
 
-        _gen = pipeline("text-generation", model=LOCAL_MODEL)
-    else:
-        _gen = None
-except Exception:
+    _gen = pipeline("text-generation", model=LOCAL_MODEL)
+else:
     _gen = None
 
 
@@ -28,7 +27,33 @@ def supported_backends() -> list[str]:
     return ["local"]
 
 
-def generate(prompt: str, max_tokens: int = 128) -> str:
+Message = Mapping[str, str]
+
+
+def _render_messages(messages: Sequence[Message]) -> str:
+    return "\n".join(
+        f"{message.get('role', 'user')}: {message.get('content', '')}".rstrip()
+        for message in messages
+    )
+
+
+def _extract_text(output: Any) -> str:
+    if isinstance(output, list) and output:
+        first = output[0]
+        if isinstance(first, dict):
+            generated = first.get("generated_text", "")
+            if isinstance(generated, list) and generated:
+                last = generated[-1]
+                if isinstance(last, dict) and "content" in last:
+                    return str(last["content"])
+                return str(last)
+            if isinstance(generated, str):
+                return generated
+        return str(first)
+    return str(output)
+
+
+def generate(prompt: str | Sequence[Message], max_tokens: int = 128) -> str:
     """Generate a short text continuation from the chosen backend.
 
     - If `AI_BACKEND=local` and `transformers` is available, use it.
@@ -40,9 +65,13 @@ def generate(prompt: str, max_tokens: int = 128) -> str:
                 "Local backend requested but `transformers` pipeline not available.\n"
                 "Install `transformers` and a model (or set AI_BACKEND to another backend)."
             )
-        out = _gen(prompt, max_new_tokens=max_tokens, do_sample=True)
-        if isinstance(out, list) and out:
-            return out[0].get("generated_text", "")
-        return str(out)
+        if isinstance(prompt, (list, tuple)):
+            try:
+                out = _gen(prompt, max_new_tokens=max_tokens, do_sample=True)
+            except Exception:
+                out = _gen(_render_messages(prompt), max_new_tokens=max_tokens, do_sample=True)
+        else:
+            out = _gen(prompt, max_new_tokens=max_tokens, do_sample=True)
+        return _extract_text(out)
 
     raise RuntimeError(f"Unsupported AI_BACKEND: {AI_BACKEND}. Supported: {supported_backends()}")


### PR DESCRIPTION
### Motivation
- Allow the local AI adapter to handle chat-style message lists (role/content pairs) so local models can be used in multi-turn/chat workflows.
- Make pipeline initialization safer and more predictable by checking for the `transformers` package before creating the pipeline instead of relying on import-time exception handling.
- Normalize and extract generated text from different pipeline output shapes so calling code receives a consistent string.

### Description
- Use `importlib.util.find_spec("transformers")` to detect availability of `transformers` and only initialize the pipeline when present, setting `_gen = None` otherwise.
- Add `Message = Mapping[str, str]` and a `_render_messages` helper to render chat-style message sequences into a single prompt string when needed.
- Add `_extract_text` helper to normalize various `transformers` pipeline return shapes and reliably extract assistant content.
- Extend `generate` to accept `str` or `Sequence[Message]`, attempt to call the pipeline with a message sequence and fall back to rendering with `_render_messages` on failure, and return normalized text via `_extract_text`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ece860b0832299350decda6aea28)