### PR TITLE
Add EJCE core engine and JSON schema bundle

### DIFF
--- a/schema/ejce/AppellateOutput.schema.json
+++ b/schema/ejce/AppellateOutput.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/AppellateOutput.schema.json",
+  "title": "AppellateOutputSchema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["statement_of_facts", "argument", "relief_requested", "citations"],
+  "properties": {
+    "statement_of_facts": {"type": "array", "items": {"type": "string"}, "default": []},
+    "argument": {"type": "array", "items": {"type": "string"}, "default": []},
+    "relief_requested": {"type": "array", "items": {"type": "string"}, "default": []},
+    "citations": {"type": "array", "items": {"type": "string"}, "default": []},
+    "appendices": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/DeviationEdge.schema.json
+++ b/schema/ejce/DeviationEdge.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/DeviationEdge.schema.json",
+  "title": "DeviationEdge",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "deviation_id",
+    "judicial_action_id",
+    "mdp_node_id",
+    "deviation_code",
+    "severity",
+    "authority_violated",
+    "created_at"
+  ],
+  "properties": {
+    "deviation_id": {"type": "string"},
+    "evidence_atom_id": {"type": ["string", "null"]},
+    "judicial_action_id": {"type": "string"},
+    "mdp_node_id": {"type": "string"},
+    "deviation_code": {"type": "string", "enum": ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8", "D9", "D10"]},
+    "severity": {"type": "string", "enum": ["Low", "Medium", "High", "Critical"]},
+    "authority_violated": {"type": "string"},
+    "authority_class": {"type": ["string", "null"]},
+    "explanation": {"type": ["string", "null"]},
+    "created_at": {"type": "string", "format": "date-time"},
+    "weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "severity_weight": {"type": "number"},
+        "authority_weight": {"type": "number"},
+        "mdp_importance": {"type": "number"}
+      }
+    }
+  }
+}

--- a/schema/ejce/DeviationGraph.schema.json
+++ b/schema/ejce/DeviationGraph.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/DeviationGraph.schema.json",
+  "title": "DeviationGraph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["graph_id", "edges", "generated_at"],
+  "properties": {
+    "graph_id": {"type": "string"},
+    "edges": {"type": "array", "items": {"$ref": "DeviationEdge.schema.json"}},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "notes": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/EvidenceAtom.schema.json
+++ b/schema/ejce/EvidenceAtom.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/EvidenceAtom.schema.json",
+  "title": "EvidenceAtom++",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "atom_id",
+    "atom_type",
+    "source_path",
+    "record_status"
+  ],
+  "properties": {
+    "atom_id": {"type": "string", "minLength": 3},
+    "atom_type": {
+      "type": "string",
+      "enum": ["order", "transcript", "exhibit", "docket", "notice", "motion", "brief", "correspondence", "other"]
+    },
+    "source_path": {"type": "string"},
+    "record_status": {
+      "type": "string",
+      "enum": ["unknown", "created", "filed", "offered", "admitted", "excluded", "considered", "ignored", "relied_without_admission"]
+    },
+    "authority_pinpoint": {"type": ["string", "null"], "description": "Law pinpoint (rule + subsection + effective date)"},
+    "fact_pinpoint": {"type": ["string", "null"], "description": "Fact pinpoint (path + page/line/Bates/timecode)"},
+    "cited_authorities": {"type": "array", "items": {"type": "string"}, "default": []},
+    "judicial_acknowledged": {"type": "boolean", "default": false},
+    "judicial_ruled_on": {"type": "boolean", "default": false},
+    "judicial_excluded": {"type": "boolean", "default": false},
+    "judicial_relied_upon": {"type": "boolean", "default": false}
+  }
+}

--- a/schema/ejce/EvidenceStateMachine.schema.json
+++ b/schema/ejce/EvidenceStateMachine.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/EvidenceStateMachine.schema.json",
+  "title": "EvidenceStateMachine",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["atom_id", "state", "state_ts"],
+  "properties": {
+    "atom_id": {"type": "string"},
+    "state": {
+      "type": "string",
+      "enum": [
+        "CREATED",
+        "FILED",
+        "OFFERED",
+        "ACCEPTED",
+        "EXCLUDED",
+        "IGNORED",
+        "RELIED_WITHOUT_ADMISSION",
+        "SEALED"
+      ]
+    },
+    "state_ts": {"type": "string", "format": "date-time"},
+    "note": {"type": ["string", "null"]}
+  }
+}

--- a/schema/ejce/JTCEligibilityGate.schema.json
+++ b/schema/ejce/JTCEligibilityGate.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/JTCEligibilityGate.schema.json",
+  "title": "JTCEligibilityGate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["eligible", "gate_trace"],
+  "properties": {
+    "eligible": {"type": "boolean"},
+    "absolute_training_breach": {"type": "boolean"},
+    "silence_vector_count": {"type": "integer", "minimum": 0},
+    "causal_chain_verified": {"type": "boolean"},
+    "alternative_lawful_explanation_attempted": {"type": "boolean"},
+    "alternative_lawful_explanation_found": {"type": "boolean"},
+    "gate_trace": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/JudicialActionNode.schema.json
+++ b/schema/ejce/JudicialActionNode.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/JudicialActionNode.schema.json",
+  "title": "JudicialActionNode",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["action_id", "judge_id", "case_id", "action_type", "date"],
+  "properties": {
+    "action_id": {"type": "string"},
+    "judge_id": {"type": "string"},
+    "case_id": {"type": "string"},
+    "action_type": {
+      "type": "string",
+      "enum": ["order", "oral_ruling", "written_ruling", "hearing_management", "omission", "delay", "sanction", "contempt"]
+    },
+    "date": {"type": "string", "format": "date-time"},
+    "authority_cited": {"type": "array", "items": {"type": "string"}, "default": []},
+    "evidence_referenced": {"type": "array", "items": {"type": "string"}, "default": []},
+    "evidence_required": {"type": "array", "items": {"type": "string"}, "default": []},
+    "findings_made": {"type": "array", "items": {"type": "string"}, "default": []},
+    "findings_required": {"type": "array", "items": {"type": "string"}, "default": []},
+    "silence_vectors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "missing_findings",
+          "ignored_evidence",
+          "ignored_objection",
+          "standard_not_articulated",
+          "benchbook_deviation",
+          "reliance_without_admission"
+        ]
+      },
+      "default": []
+    }
+  }
+}

--- a/schema/ejce/MDPNode.schema.json
+++ b/schema/ejce/MDPNode.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/MDPNode.schema.json",
+  "title": "MDPNode",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mdp_node_id", "vehicle", "triggering_condition"],
+  "properties": {
+    "mdp_node_id": {"type": "string"},
+    "vehicle": {"type": "string"},
+    "triggering_condition": {"type": "string"},
+    "required_steps": {"type": "array", "items": {"type": "string"}, "default": []},
+    "required_findings": {"type": "array", "items": {"type": "string"}, "default": []},
+    "evidence_classes_required": {"type": "array", "items": {"type": "string"}, "default": []},
+    "discretion_bounds": {"type": ["string", "null"]},
+    "prohibited_shortcuts": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/OmissionScore.schema.json
+++ b/schema/ejce/OmissionScore.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/OmissionScore.schema.json",
+  "title": "OmissionScore",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["action_id", "score", "components"],
+  "properties": {
+    "action_id": {"type": "string"},
+    "score": {"type": "number", "minimum": 0},
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "missing_findings_count",
+        "ignored_evidence_count",
+        "benchbook_deviation_weight",
+        "reliance_without_admission_count",
+        "ignored_objection_count"
+      ],
+      "properties": {
+        "missing_findings_count": {"type": "integer", "minimum": 0},
+        "ignored_evidence_count": {"type": "integer", "minimum": 0},
+        "benchbook_deviation_weight": {"type": "number", "minimum": 0},
+        "reliance_without_admission_count": {"type": "integer", "minimum": 0},
+        "ignored_objection_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "notes": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/PatternConfidenceIndex.schema.json
+++ b/schema/ejce/PatternConfidenceIndex.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/PatternConfidenceIndex.schema.json",
+  "title": "PatternConfidenceIndex",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["judge_id", "case_id", "confidence_score", "window"],
+  "properties": {
+    "judge_id": {"type": "string"},
+    "case_id": {"type": "string"},
+    "confidence_score": {"type": "number", "minimum": 0},
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": {"type": "string", "format": "date-time"},
+        "end": {"type": "string", "format": "date-time"}
+      }
+    },
+    "critical_deviation_count": {"type": "integer", "minimum": 0},
+    "repeat_deviation_types": {"type": "array", "items": {"type": "string"}, "default": []},
+    "motion_type_clusters": {"type": "array", "items": {"type": "string"}, "default": []},
+    "time_decay_model": {"type": "string", "enum": ["none", "linear", "exp"], "default": "exp"}
+  }
+}

--- a/schema/ejce/RemedyEligibilityMap.schema.json
+++ b/schema/ejce/RemedyEligibilityMap.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/RemedyEligibilityMap.schema.json",
+  "title": "RemedyEligibilityMap",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["eligible_remedies", "gate_trace"],
+  "properties": {
+    "eligible_remedies": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["Vacatur", "Remand", "Reassignment", "Superintending_Control", "Federal_Overlay", "Stay", "Clarification", "Reconsideration"]
+      }
+    },
+    "gate_trace": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/TrainingRule.schema.json
+++ b/schema/ejce/TrainingRule.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigationos.local/schemas/ejce/TrainingRule.schema.json",
+  "title": "TrainingRule",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["training_rule_id", "source", "instruction", "presumption_level"],
+  "properties": {
+    "training_rule_id": {"type": "string"},
+    "source": {"type": "string"},
+    "instruction": {"type": "string"},
+    "presumption_level": {"type": "string", "enum": ["low", "medium", "high", "absolute"]},
+    "applies_to": {"type": "array", "items": {"type": "string"}, "default": []},
+    "authority_links": {"type": "array", "items": {"type": "string"}, "default": []}
+  }
+}

--- a/schema/ejce/schemas_manifest.json
+++ b/schema/ejce/schemas_manifest.json
@@ -1,0 +1,18 @@
+{
+  "bundle": "ejce-core",
+  "schema_version": "2.1.0",
+  "core_components": [
+    "EvidenceAtom.schema.json",
+    "EvidenceStateMachine.schema.json",
+    "JudicialActionNode.schema.json",
+    "OmissionScore.schema.json",
+    "MDPNode.schema.json",
+    "TrainingRule.schema.json",
+    "DeviationEdge.schema.json",
+    "DeviationGraph.schema.json",
+    "PatternConfidenceIndex.schema.json",
+    "RemedyEligibilityMap.schema.json",
+    "JTCEligibilityGate.schema.json",
+    "AppellateOutput.schema.json"
+  ]
+}

--- a/src/ejce/__init__.py
+++ b/src/ejce/__init__.py
@@ -1,0 +1,23 @@
+"""Evidence ⇄ Judiciary Correlation Engine (EJCE) public API."""
+
+from .engine import (
+    EvidenceAtom,
+    JudicialActionNode,
+    MDPNode,
+    TrainingRule,
+    DeviationEdge,
+    EJCEConfig,
+    EJCEAnalysis,
+    run_ejce_analysis,
+)
+
+__all__ = [
+    "EvidenceAtom",
+    "JudicialActionNode",
+    "MDPNode",
+    "TrainingRule",
+    "DeviationEdge",
+    "EJCEConfig",
+    "EJCEAnalysis",
+    "run_ejce_analysis",
+]

--- a/src/ejce/engine.py
+++ b/src/ejce/engine.py
@@ -1,0 +1,291 @@
+"""Evidence ⇄ Judiciary Correlation Engine (EJCE).
+
+MI-only, evidence-locked, fail-closed analysis core.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+class Severity(str, Enum):
+    low = "Low"
+    medium = "Medium"
+    high = "High"
+    critical = "Critical"
+
+
+class DeviationCode(str, Enum):
+    missing_findings = "D1"
+    ignored_evidence = "D2"
+    relied_without_admission = "D3"
+    wrong_standard = "D4"
+    benchbook_deviation = "D5"
+    ignored_objection = "D6"
+    procedural_shortcut = "D7"
+    retaliatory_sequence = "D8"
+    jurisdictional_excess = "D9"
+    pattern_repeat = "D10"
+
+
+@dataclass(frozen=True)
+class EvidenceAtom:
+    atom_id: str
+    atom_type: str
+    source_path: str
+    record_status: str
+    authority_pinpoint: Optional[str] = None
+    fact_pinpoint: Optional[str] = None
+    cited_authorities: Sequence[str] = field(default_factory=tuple)
+    judicial_acknowledged: bool = False
+    judicial_ruled_on: bool = False
+    judicial_excluded: bool = False
+    judicial_relied_upon: bool = False
+
+    def validate(self) -> None:
+        if not self.atom_id:
+            raise ValueError("EvidenceAtom.atom_id is required")
+        if not self.source_path:
+            raise ValueError("EvidenceAtom.source_path is required")
+
+
+@dataclass(frozen=True)
+class JudicialActionNode:
+    action_id: str
+    judge_id: str
+    case_id: str
+    action_type: str
+    date: datetime
+    authority_cited: Sequence[str] = field(default_factory=tuple)
+    evidence_referenced: Sequence[str] = field(default_factory=tuple)
+    evidence_required: Sequence[str] = field(default_factory=tuple)
+    findings_made: Sequence[str] = field(default_factory=tuple)
+    findings_required: Sequence[str] = field(default_factory=tuple)
+    silence_vectors: Sequence[str] = field(default_factory=tuple)
+
+    def validate(self) -> None:
+        if not self.action_id:
+            raise ValueError("JudicialActionNode.action_id is required")
+        if not self.judge_id:
+            raise ValueError("JudicialActionNode.judge_id is required")
+        if not self.case_id:
+            raise ValueError("JudicialActionNode.case_id is required")
+
+
+@dataclass(frozen=True)
+class MDPNode:
+    mdp_node_id: str
+    vehicle: str
+    triggering_condition: str
+    required_steps: Sequence[str] = field(default_factory=tuple)
+    required_findings: Sequence[str] = field(default_factory=tuple)
+    evidence_classes_required: Sequence[str] = field(default_factory=tuple)
+    prohibited_shortcuts: Sequence[str] = field(default_factory=tuple)
+
+    def validate(self) -> None:
+        if not self.mdp_node_id:
+            raise ValueError("MDPNode.mdp_node_id is required")
+        if not self.vehicle:
+            raise ValueError("MDPNode.vehicle is required")
+
+
+@dataclass(frozen=True)
+class TrainingRule:
+    training_rule_id: str
+    source: str
+    instruction: str
+    presumption_level: str
+
+    def weight(self) -> float:
+        weights = {"low": 0.5, "medium": 1.0, "high": 2.0, "absolute": 3.0}
+        return weights.get(self.presumption_level, 0.0)
+
+
+@dataclass(frozen=True)
+class DeviationEdge:
+    deviation_id: str
+    deviation_code: DeviationCode
+    severity: Severity
+    judicial_action_id: str
+    mdp_node_id: str
+    evidence_atom_id: Optional[str]
+    authority_violated: str
+    explanation: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EJCEConfig:
+    criticality_min: float = 1.0
+    pattern_min: float = 1.0
+    harm_min: float = 1.0
+    jurisdiction_min: float = 1.0
+    integrity_min: float = 2.0
+
+
+@dataclass(frozen=True)
+class EJCEIndices:
+    criticality: float
+    pattern_confidence: float
+    procedural_harm: float
+    jurisdiction_risk: float
+    integrity_risk: float
+
+
+@dataclass(frozen=True)
+class EJCEGates:
+    remedies: Sequence[str]
+    jtc_eligible: bool
+
+
+@dataclass(frozen=True)
+class EJCEAnalysis:
+    deviations: Sequence[DeviationEdge]
+    indices: EJCEIndices
+    gates: EJCEGates
+    omission_scores: Dict[str, float]
+
+
+def _severity_weight(severity: Severity) -> float:
+    return {
+        Severity.low: 0.5,
+        Severity.medium: 1.0,
+        Severity.high: 2.0,
+        Severity.critical: 3.0,
+    }[severity]
+
+
+def _authority_weight(authority: str) -> float:
+    if authority.startswith("MCR") or authority.startswith("MCL"):
+        return 1.5
+    if authority.startswith("MRE"):
+        return 1.3
+    if authority.startswith("MJI") or authority.startswith("SCAO"):
+        return 1.2
+    return 1.0
+
+
+def _score_omissions(action: JudicialActionNode) -> float:
+    missing_findings = len(set(action.findings_required) - set(action.findings_made))
+    ignored_evidence = max(0, len(action.evidence_required) - len(action.evidence_referenced))
+    ignored_objections = action.silence_vectors.count("ignored_objection")
+    benchbook_deviation = action.silence_vectors.count("benchbook_deviation") * 1.5
+    reliance_without_admission = action.silence_vectors.count("reliance_without_admission")
+    return (
+        missing_findings
+        + ignored_evidence
+        + ignored_objections
+        + benchbook_deviation
+        + reliance_without_admission
+    )
+
+
+def _detect_missing_findings(action: JudicialActionNode, mdp: MDPNode) -> Iterable[DeviationEdge]:
+    missing = set(mdp.required_findings) - set(action.findings_made)
+    for finding in sorted(missing):
+        yield DeviationEdge(
+            deviation_id=f"DEV-{action.action_id}-{finding}",
+            deviation_code=DeviationCode.missing_findings,
+            severity=Severity.critical,
+            judicial_action_id=action.action_id,
+            mdp_node_id=mdp.mdp_node_id,
+            evidence_atom_id=None,
+            authority_violated=f"Missing finding required by {mdp.vehicle}: {finding}",
+        )
+
+
+def _detect_ignored_evidence(
+    action: JudicialActionNode, mdp: MDPNode, evidence: Dict[str, EvidenceAtom]
+) -> Iterable[DeviationEdge]:
+    referenced = set(action.evidence_referenced)
+    for atom_id, atom in evidence.items():
+        if atom_id not in referenced:
+            yield DeviationEdge(
+                deviation_id=f"DEV-{action.action_id}-{atom_id}",
+                deviation_code=DeviationCode.ignored_evidence,
+                severity=Severity.high,
+                judicial_action_id=action.action_id,
+                mdp_node_id=mdp.mdp_node_id,
+                evidence_atom_id=atom_id,
+                authority_violated="Evidence in record omitted from action",
+            )
+
+
+def _compute_indices(
+    deviations: Sequence[DeviationEdge],
+    omission_scores: Dict[str, float],
+    training_rules: Sequence[TrainingRule],
+) -> EJCEIndices:
+    criticality = sum(
+        _severity_weight(dev.severity) * _authority_weight(dev.authority_violated)
+        for dev in deviations
+        if dev.severity in {Severity.high, Severity.critical}
+    )
+    pattern_confidence = len({dev.judicial_action_id for dev in deviations})
+    procedural_harm = sum(omission_scores.values())
+    jurisdiction_risk = sum(
+        1.0
+        for dev in deviations
+        if dev.deviation_code == DeviationCode.jurisdictional_excess
+    )
+    integrity_risk = sum(rule.weight() for rule in training_rules)
+    return EJCEIndices(
+        criticality=criticality,
+        pattern_confidence=pattern_confidence,
+        procedural_harm=procedural_harm,
+        jurisdiction_risk=jurisdiction_risk,
+        integrity_risk=integrity_risk,
+    )
+
+
+def _apply_gates(indices: EJCEIndices, config: EJCEConfig, training_rules: Sequence[TrainingRule]) -> EJCEGates:
+    remedies: List[str] = []
+    if (
+        indices.criticality >= config.criticality_min
+        and indices.pattern_confidence >= config.pattern_min
+        and indices.procedural_harm >= config.harm_min
+        and (indices.jurisdiction_risk >= config.jurisdiction_min or indices.integrity_risk >= config.integrity_min)
+    ):
+        remedies.extend(["Reassignment", "Superintending_Control"])
+    jtc_eligible = (
+        any(rule.presumption_level == "absolute" for rule in training_rules)
+        and indices.procedural_harm >= config.harm_min
+    )
+    return EJCEGates(remedies=remedies, jtc_eligible=jtc_eligible)
+
+
+def run_ejce_analysis(
+    evidence_atoms: Sequence[EvidenceAtom],
+    judicial_actions: Sequence[JudicialActionNode],
+    mdp_nodes: Sequence[MDPNode],
+    training_rules: Sequence[TrainingRule],
+    config: Optional[EJCEConfig] = None,
+) -> EJCEAnalysis:
+    config = config or EJCEConfig()
+    evidence = {atom.atom_id: atom for atom in evidence_atoms}
+    for atom in evidence_atoms:
+        atom.validate()
+    for action in judicial_actions:
+        action.validate()
+    for mdp in mdp_nodes:
+        mdp.validate()
+
+    deviations: List[DeviationEdge] = []
+    omission_scores: Dict[str, float] = {}
+
+    for action in judicial_actions:
+        for mdp in mdp_nodes:
+            deviations.extend(_detect_missing_findings(action, mdp))
+            deviations.extend(_detect_ignored_evidence(action, mdp, evidence))
+        omission_scores[action.action_id] = _score_omissions(action)
+
+    indices = _compute_indices(deviations, omission_scores, training_rules)
+    gates = _apply_gates(indices, config, training_rules)
+
+    return EJCEAnalysis(
+        deviations=deviations,
+        indices=indices,
+        gates=gates,
+        omission_scores=omission_scores,
+    )


### PR DESCRIPTION
### Motivation
- Implement an MI-only, evidence-first analysis core to detect judicial deviations and make deterministic remedy/JTC gating decisions. 
- Provide an executable design surface that is evidence-locked, fail-closed, and suitable for downstream graph, harvester, and filing integrations. 
- Ship machine-readable contracts (JSON Schemas) so other modules and agents can validate and interoperate with the EJCE data model. 

### Description
- Add the EJCE analysis engine at `src/ejce/engine.py` which defines `EvidenceAtom`, `JudicialActionNode`, `MDPNode`, `TrainingRule`, `DeviationEdge`, index computation (CI/PCI/PHI/JRI/IRI), and deterministic gate logic for remedies and JTC eligibility. 
- Expose a compact public API in `src/ejce/__init__.py` including `run_ejce_analysis`, `EJCEConfig`, and `EJCEAnalysis` for easy integration. 
- Add a bundle of 12 JSON Schema artifacts under `schema/ejce/` (including `EvidenceAtom.schema.json`, `JudicialActionNode.schema.json`, `DeviationEdge.schema.json`, `DeviationGraph.schema.json`, `AppellateOutput.schema.json`, etc.) plus a `schemas_manifest.json` to enumerate the core components. 
- Implement lightweight validation and omission scoring logic in the engine and ensure the gating thresholds are configurable via `EJCEConfig`. 

### Testing
- No automated tests were executed as part of this change. 
- The Python engine includes `validate()` guards on core dataclasses to support runtime validation during downstream test runs or integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ecba7c50832289f14b73b683766b)