### PR TITLE
Enhance MCL Plane Suite evidence outputs; add Drive Bucket Forger and overhaul organizer

### DIFF
--- a/LAUNCH.bat
+++ b/LAUNCH.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+set PYTHON=python
+"%PYTHON%" "%SCRIPT_DIR%OUT\code\mcl_plane_suite.py" --in "%SCRIPT_DIR%IN" --out "%SCRIPT_DIR%OUT" --mode converge --adversarial true --web false
+endlocal

--- a/LAUNCH.ps1
+++ b/LAUNCH.ps1
@@ -1,0 +1,3 @@
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$python = "python"
+& $python (Join-Path $root "OUT\code\mcl_plane_suite.py") --in (Join-Path $root "IN") --out (Join-Path $root "OUT") --mode converge --adversarial true --web false

--- a/LITIGATIONOS_DRIVE_BUCKET_FORGER_v2026_01_27D.py
+++ b/LITIGATIONOS_DRIVE_BUCKET_FORGER_v2026_01_27D.py
@@ -1,0 +1,1785 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LITIGATIONOS_DRIVE_BUCKET_FORGER_v2026_01_27D.py
+
+"Deep Hydration" upgrade of the Drive Bucket Forger spine tool.
+
+WHAT’S NEW vs 01_27C (high-signal upgrades)
+1) Graph Data Pipeline Engineering (Bronze/Silver/Gold) hardened
+   - Silver emits JSONL + CSV + SQLite DDL + Neo4j CSV + LOAD.cypher
+   - Gold emits:
+     - virtual_graph.sqlite (graph virtualization) with indices + built-in queries + query pack export
+     - graph_viewer.html (offline) with deterministic physics layout
+     - dashboard_index.html linking to key artifacts
+
+2) Graph Data Virtualization (practical, local-first)
+   - SQLite “virtual graph” database:
+       nodes(node_id,label,props_json)
+       edges(edge_id,type,start_id,end_id,props_json)
+   - Built-in query runner (--vquery) + query pack emitter RUN/GRAPH_PIPELINE/gold/queries/*.sql
+
+3) ERD_SUPERSET_FED_BLUEPRINT (schema-first superset)
+   - Emits JSON + MD + DOT + HTML ERD viewer
+   - Adds JSON-Schema for nodes/edges
+   - Adds SQLite DDL for overlay entities (future ingestion), without requiring them now
+
+4) Physics Engine (deterministic)
+   - fast: O(n) degree-radial placement (default)
+   - full: iterative force simulation (uses numpy if present; else degrades to grid-approx)
+   - grid: O(n) repulsion approximation, dependency-free; used automatically when numpy missing
+
+5) Convergence cycles (watch mode) now emits:
+   - RUN/DELTA/graph_delta.json and inventory_delta.json per cycle
+   - fingerprints + stabilized cycles counter
+
+6) “Adversarial / rights / negative statement” harvesting (lightweight, dependency-free)
+   - content scan can emit:
+       RUN/adversarial_hits.jsonl : normalized hits with EvidenceAtom-style pointers (EAID)
+       RUN/GRAPH_PIPELINE/silver/content_flags.jsonl : graph-ready flags
+   - No invented facts: it only reports literal term hits + excerpts + offsets.
+
+7) Transactional apply (move/copy) with resumable apply log
+   - RUN/APPLY/apply_log.jsonl + apply_stats.json
+   - Safe defaults: plan-only unless you opt-in to apply
+   - “Bumpers not blockers”: apply proceeds while logging WARN/HARD bumpers; only stops on explicit --halt-on-hard
+
+8) Empty folder cleanup planning (never deletes unless you ask)
+   - RUN/cleanup_empty_folders_plan.jsonl (plan)
+   - --apply-cleanup to remove only folders verified empty after operations (optional)
+
+9) CyclePack forging (portable run bundle)
+   - --forge-cyclepack emits RUN/CYCLEPACK_<run_id>.zip with manifests + key outputs
+
+Design invariants (kept):
+- Non-destructive by default (plan-only).
+- Append-only logs (JSONL) for reproducibility.
+- Deterministic classification and graph IDs.
+- Hard exclusion: C:\\ and OS system paths are never scanned by default.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import time
+import zipfile
+import zlib
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Iterable, Set, Any
+
+APP_VER = "v2026_01_27D"
+
+# -------------------------
+# Buckets (<=15)
+# -------------------------
+DEFAULT_BUCKETS: List[Tuple[str, str]] = [
+    ("B01_TEXT", "txt, md, rtf, log, ini, yaml, yml, toml"),
+    ("B02_DATA", "csv, tsv, json, jsonl, parquet, sqlite, db"),
+    ("B03_DOCS", "doc, docx, odt, pdf (non-OCR isolated separately), xls/xlsx, ppt/pptx"),
+    ("B04_CODE", "py, js, ts, java, cs, cpp, c, go, rs, sh, ps1, bat"),
+    ("B05_WEB", "html, htm, css, wasm"),
+    ("B06_IMAGES", "png, jpg, jpeg, gif, webp, tif, tiff, bmp"),
+    ("B07_AUDIO", "mp3, wav, m4a, flac, ogg"),
+    ("B08_VIDEO", "mp4, mov, mkv, avi"),
+    ("B09_ARCHIVES", "zip, 7z, rar, tar, gz"),
+    ("B10_EXEC", "exe, msi, apk, appimage"),
+    ("B11_FONTS", "ttf, otf, woff, woff2"),
+    ("B12_CONFIG", "conf, cfg, reg, env"),
+    ("B13_EMAIL", "eml, msg, mbox"),
+    ("B14_OCR_QUEUE", "pdf needing OCR (detected/flagged)"),
+    ("B15_MISC", "everything else"),
+]
+
+TEXT_EXT = {".txt", ".md", ".rtf", ".log", ".ini", ".yaml", ".yml", ".toml"}
+DATA_EXT = {".csv", ".tsv", ".json", ".jsonl", ".parquet", ".sqlite", ".db"}
+DOC_EXT = {".doc", ".docx", ".odt", ".pdf", ".xls", ".xlsx", ".ppt", ".pptx"}
+CODE_EXT = {".py", ".js", ".ts", ".java", ".cs", ".cpp", ".c", ".go", ".rs", ".sh", ".ps1", ".bat"}
+WEB_EXT = {".html", ".htm", ".css", ".wasm"}
+IMG_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".tif", ".tiff", ".bmp"}
+AUD_EXT = {".mp3", ".wav", ".m4a", ".flac", ".ogg"}
+VID_EXT = {".mp4", ".mov", ".mkv", ".avi"}
+ARC_EXT = {".zip", ".7z", ".rar", ".tar", ".gz"}
+EXE_EXT = {".exe", ".msi", ".apk", ".appimage"}
+FONT_EXT = {".ttf", ".otf", ".woff", ".woff2"}
+CFG_EXT = {".conf", ".cfg", ".reg", ".env"}
+EMAIL_EXT = {".eml", ".msg", ".mbox"}
+
+# -------------------------
+# Version family heuristics
+# -------------------------
+VERSION_PATTERNS = [
+    re.compile(r"(?i)(?:^|[ _-])v(\d+(?:\.\d+){0,3})(?:$|[ _-])"),
+    re.compile(r"(?i)(?:^|[ _-])(\d{4}[-_]\d{2}[-_]\d{2})(?:$|[ _-])"),
+    re.compile(r"(?i)(?:^|[ _-])(\d{8})(?:$|[ _-])"),
+    re.compile(r"(?i)(?:^|[ _-])(final)(?:$|[ _-])"),
+]
+
+# -------------------------
+# Misconduct Vectors (seed)
+# -------------------------
+DEFAULT_MV_TAXONOMY: Dict[str, Dict[str, Any]] = {
+    "MV01": {
+        "name": "Bias/Partiality",
+        "signals": ["Asymmetric rulings", "Credibility favoritism", "Unexplained deviations", "Outcome-driven findings"],
+        "proof": ["ContradictionMap", "AuthorityTriples", "Order-vs-Record deltas", "Transcript omissions"],
+        "remedies": ["MotionToDisqualify", "MotionForReconsideration", "AppealIssue", "JTCComplaint"],
+    },
+    "MV02": {
+        "name": "Weaponized_PPO",
+        "signals": ["Ex parte overreach", "Scope inflation", "Evidentiary asymmetry", "Parenting-time interference"],
+        "proof": ["PPO record gaps", "Statutory noncompliance", "Hearing timing defects"],
+        "remedies": ["MotionToQuashOrModify", "Appeal", "CollateralRecord", "JTCComplaint"],
+    },
+    "MV03": {
+        "name": "Retaliatory_Contempt",
+        "signals": ["Contempt after protected filings", "Vague orders", "Impossible compliance"],
+        "proof": ["Order ambiguity", "Compliance timeline", "Authority mismatch"],
+        "remedies": ["MotionToVacate", "Stay", "Appeal", "DueProcessObjections"],
+    },
+}
+
+DEFAULT_EVENT_TO_MV_MAP: Dict[str, List[str]] = {
+    "EVIDENCE_EXCLUDED": ["MV01"],
+    "CROSS_EXAM_LIMITED": ["MV01"],
+    "EX_PARTE_PPO_SCOPE": ["MV02"],
+    "PPO_USED_TO_BLOCK_PT": ["MV02"],
+    "CONTEMPT_AFTER_FILING": ["MV03"],
+    "AMBIGUOUS_ORDER": ["MV03"],
+}
+
+DEFAULT_BUMPER_QUERY_PACK: Dict[str, Any] = {
+    "queries": [
+        {"id": "BQ01", "name": "High severity bumpers", "match": {"severity": ["warn", "hard"]}, "group_by": ["id", "where"], "limit": 200},
+        {"id": "BQ02", "name": "Bumpers mapped to MV02", "match": {"mv": ["MV02"]}, "group_by": ["id", "where"], "limit": 500},
+    ]
+}
+
+# -------------------------
+# Adversarial lexicon (term hits only)
+# -------------------------
+DEFAULT_ADVERSARIAL_LEXICON: Dict[str, List[str]] = {
+    "NEGATIVE_CHARACTERIZATION": [
+        "unfit", "abusive", "dangerous", "unstable", "harassment", "stalking", "threat", "violent",
+        "kidnap", "alienat", "contempt", "violat", "fraud", "perjur", "lying", "false", "weaponiz"
+    ],
+    "RIGHTS_PROCESS_VIOLATION": [
+        "due process", "no notice", "without notice", "denied hearing", "refused evidence", "excluded evidence",
+        "not allowed", "muted", "bias", "partial", "ex parte", "no opportunity", "no counsel"
+    ],
+    "RECORD_DEFECT": [
+        "no transcript", "missing transcript", "off the record", "not recorded", "inaudible", "omitted",
+        "order does not reflect", "discrepancy", "record mismatch"
+    ],
+}
+
+DEFAULT_VIRTUAL_QUERY_PACK: Dict[str, str] = {
+    "bucket_counts": """
+        SELECT json_extract(n.props_json, '$.bucket_id') AS bucket_id, count(*) AS n
+        FROM edges e
+        JOIN nodes n ON n.node_id = e.end_id
+        WHERE e.type='IN_BUCKET' AND n.label='Bucket'
+        GROUP BY bucket_id
+        ORDER BY n DESC;
+    """,
+    "bumper_counts": """
+        SELECT json_extract(props_json, '$.id') AS bumper_id, json_extract(props_json, '$.mv') AS mv, count(*) AS n
+        FROM nodes
+        WHERE label='Bumper'
+        GROUP BY bumper_id, mv
+        ORDER BY n DESC;
+    """,
+    "largest_files": """
+        SELECT json_extract(props_json,'$.path') AS path, json_extract(props_json,'$.size') AS size
+        FROM nodes
+        WHERE label='File'
+        ORDER BY size DESC
+        LIMIT 50;
+    """,
+    "dup_groups": """
+        SELECT json_extract(props_json,'$.group_id') AS group_id, json_extract(props_json,'$.count') AS count, json_extract(props_json,'$.canonical') AS canonical
+        FROM nodes
+        WHERE label='DuplicateGroup'
+        ORDER BY count DESC
+        LIMIT 200;
+    """,
+    "version_families": """
+        SELECT json_extract(props_json,'$.family') AS family, json_extract(props_json,'$.count') AS count, json_extract(props_json,'$.canonical') AS canonical
+        FROM nodes
+        WHERE label='VersionFamily'
+        ORDER BY count DESC
+        LIMIT 200;
+    """,
+}
+
+# -------------------------
+# Dataclasses
+# -------------------------
+@dataclass
+class FileRecord:
+    path: str
+    drive: str
+    relpath: str
+    name: str
+    ext: str
+    size: int
+    mtime: float
+    bucket: str
+    rule_id: str
+    rule_reason: str
+    version_family: Optional[str] = None
+    version_score: Optional[float] = None
+    sha256: Optional[str] = None
+    quick_sig: Optional[str] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class PlannedAction:
+    action: str  # MOVE | COPY | SKIP
+    src: str
+    dst: str
+    bucket: str
+    reason: str
+    size: int
+
+
+@dataclass
+class Bumper:
+    id: str
+    severity: str  # soft | warn | hard
+    where: str
+    msg: str
+    detail: Optional[str] = None
+    mv: Optional[str] = None
+    ts: str = ""
+
+
+# -------------------------
+# Utilities
+# -------------------------
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def safe_mkdir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(path: Path, obj: object) -> None:
+    safe_mkdir(path.parent)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def write_text(path: Path, s: str) -> None:
+    safe_mkdir(path.parent)
+    path.write_text(s, encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: List[dict]) -> None:
+    safe_mkdir(path.parent)
+    with path.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def append_jsonl(path: Path, row: dict) -> None:
+    safe_mkdir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def sha256_file(path: Path, chunk: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            b = f.read(chunk)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def quick_signature(path: Path, head: int = 65536, tail: int = 65536) -> str:
+    st = path.stat()
+    size = st.st_size
+    h = hashlib.sha1()
+    with path.open("rb") as f:
+        h.update(f.read(min(head, size)))
+        if size > head + tail:
+            f.seek(max(0, size - tail))
+            h.update(f.read(tail))
+    h.update(str(size).encode("utf-8"))
+    return h.hexdigest()
+
+
+def stable_id_for_path(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8", errors="ignore")).hexdigest()[:16]
+
+
+def integrity_key(path: Path) -> str:
+    """
+    Durable-ish integrity key (not a cryptographic commitment): BundleUID+EntryPath+CRC32+bytes+mtime
+    CRC32 is over first+last bytes (quick), not full file.
+    """
+    try:
+        size = path.stat().st_size
+        mtime = int(path.stat().st_mtime)
+        raw = path.read_bytes()
+        sample = raw[:65536] + raw[-65536:] if len(raw) > 131072 else raw
+        crc = zlib.crc32(sample) & 0xffffffff
+        return f"IK|{path.name}|{crc:08x}|{size}|{mtime}"
+    except Exception:
+        return f"IK|{path.name}|ERROR"
+
+
+def is_system_path(p: Path) -> bool:
+    ps = str(p).lower()
+    bad = [
+        r"\windows\\", r"\program files", r"\programdata\\",
+        r"\$recycle.bin", r"\system volume information",
+        r"\appdata\\local\\temp", r"\appdata\\local\\microsoft\\windows\\inetcache",
+    ]
+    return any(b in ps for b in bad)
+
+
+def bumper(bumpers_list: List[Bumper], bid: str, severity: str, where: str, msg: str, detail: Optional[str] = None, mv: Optional[str] = None) -> None:
+    bumpers_list.append(Bumper(id=bid, severity=severity, where=where, msg=msg, detail=detail, mv=mv, ts=now_iso()))
+
+
+# -------------------------
+# Classification rules
+# -------------------------
+def classify_bucket(path: Path) -> Tuple[str, str, str]:
+    ext = path.suffix.lower()
+    name = path.name.lower()
+
+    # Extension-first
+    if ext in ARC_EXT:
+        return ("B09_ARCHIVES", "R_EXT_ARCHIVE", f"ext={ext}")
+    if ext in EXE_EXT:
+        return ("B10_EXEC", "R_EXT_EXEC", f"ext={ext}")
+    if ext in IMG_EXT:
+        return ("B06_IMAGES", "R_EXT_IMAGE", f"ext={ext}")
+    if ext in AUD_EXT:
+        return ("B07_AUDIO", "R_EXT_AUDIO", f"ext={ext}")
+    if ext in VID_EXT:
+        return ("B08_VIDEO", "R_EXT_VIDEO", f"ext={ext}")
+    if ext in FONT_EXT:
+        return ("B11_FONTS", "R_EXT_FONT", f"ext={ext}")
+    if ext in EMAIL_EXT:
+        return ("B13_EMAIL", "R_EXT_EMAIL", f"ext={ext}")
+    if ext in CODE_EXT:
+        return ("B04_CODE", "R_EXT_CODE", f"ext={ext}")
+    if ext in WEB_EXT:
+        return ("B05_WEB", "R_EXT_WEB", f"ext={ext}")
+    if ext in DATA_EXT:
+        return ("B02_DATA", "R_EXT_DATA", f"ext={ext}")
+    if ext in TEXT_EXT:
+        return ("B01_TEXT", "R_EXT_TEXT", f"ext={ext}")
+    if ext in DOC_EXT:
+        return ("B03_DOCS", "R_EXT_DOC", f"ext={ext}")
+
+    # Name hints
+    if "readme" in name:
+        return ("B01_TEXT", "R_HINT_README", "name contains readme")
+    if "schema" in name and ext in {".json", ".yml", ".yaml"}:
+        return ("B02_DATA", "R_HINT_SCHEMA", "name contains schema")
+    if "backup" in name or name.endswith(".bak"):
+        return ("B15_MISC", "R_HINT_BACKUP", "name indicates backup")
+
+    return ("B15_MISC", "R_FALLBACK", f"ext={ext or '(none)'}")
+
+
+def detect_version_family(path: Path) -> Tuple[Optional[str], Optional[float]]:
+    name = path.stem
+    tokens = re.split(r"[ _-]+", name)
+    cleaned = []
+    score = 0.0
+    for t in tokens:
+        matched = False
+        for rx in VERSION_PATTERNS:
+            if rx.search(t):
+                matched = True
+                if t.lower() == "final":
+                    score += 2.0
+                elif re.fullmatch(r"\d{4}[-_]\d{2}[-_]\d{2}", t):
+                    score += 1.0
+                elif re.fullmatch(r"\d{8}", t):
+                    score += 1.0
+                else:
+                    score += 0.8
+                break
+        if not matched:
+            cleaned.append(t)
+    family = " ".join(cleaned).strip().lower()
+    if not family:
+        return (None, None)
+    return (family, score)
+
+
+# -------------------------
+# Scanning
+# -------------------------
+def iter_files(roots: List[Path], bumpers_list: List[Bumper], include_hidden: bool = False) -> Iterable[Path]:
+    for root in roots:
+        if not root.exists():
+            bumper(bumpers_list, "ROOT_MISSING", "warn", str(root), "Root does not exist; skipping")
+            continue
+        # Gate 0: exclude C:\ unless explicitly passed
+        if os.name == "nt":
+            if str(root).lower().startswith("c:\\"):
+                bumper(bumpers_list, "GATE0_C_EXCLUDED", "hard", str(root), "C:\\ excluded by policy; remove from roots")
+                continue
+
+        for dirpath, dirnames, filenames in os.walk(root):
+            dp = Path(dirpath)
+            if is_system_path(dp):
+                continue
+            if not include_hidden:
+                dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+                filenames = [fn for fn in filenames if not fn.startswith(".")]
+            for fn in filenames:
+                p = dp / fn
+                try:
+                    if p.is_symlink():
+                        continue
+                    yield p
+                except Exception:
+                    continue
+
+
+def scan_inventory(roots: List[Path], bumpers_list: List[Bumper], compute_hashes: bool, compute_quick_sig: bool) -> List[FileRecord]:
+    recs: List[FileRecord] = []
+    for p in iter_files(roots, bumpers_list):
+        try:
+            st = p.stat()
+        except Exception as e:
+            bumper(bumpers_list, "STAT_FAIL", "soft", str(p), "Failed stat()", str(e))
+            continue
+
+        drive = p.drive if hasattr(p, "drive") else ""
+        relpath = str(p.relative_to(Path(drive + os.sep))) if drive else str(p)
+
+        bucket, rid, rreason = classify_bucket(p)
+        fam, fscore = detect_version_family(p)
+
+        fr = FileRecord(
+            path=str(p),
+            drive=drive or "ROOT",
+            relpath=relpath,
+            name=p.name,
+            ext=p.suffix.lower(),
+            size=int(st.st_size),
+            mtime=float(st.st_mtime),
+            bucket=bucket,
+            rule_id=rid,
+            rule_reason=rreason,
+            version_family=fam,
+            version_score=fscore,
+        )
+
+        if compute_quick_sig:
+            try:
+                fr.quick_sig = quick_signature(p)
+            except Exception as e:
+                bumper(bumpers_list, "QUICK_SIG_FAIL", "soft", str(p), "Quick signature failed", str(e))
+
+        if compute_hashes:
+            try:
+                fr.sha256 = sha256_file(p)
+            except Exception as e:
+                bumper(bumpers_list, "HASH_FAIL", "soft", str(p), "SHA256 failed", str(e))
+
+        recs.append(fr)
+    return recs
+
+
+# -------------------------
+# Planning
+# -------------------------
+def plan_bucket_paths(out_root: Path, recs: List[FileRecord], bumpers_list: List[Bumper], skip_existing: bool, verify_existing_hash: bool) -> List[PlannedAction]:
+    actions: List[PlannedAction] = []
+    for r in recs:
+        src = Path(r.path)
+        bucket_dir = out_root / r.bucket
+        dst = bucket_dir / src.name
+
+        if str(src).lower() == str(dst).lower():
+            actions.append(PlannedAction("SKIP", r.path, str(dst), r.bucket, "already_in_place", r.size))
+            continue
+
+        if skip_existing and dst.exists():
+            if verify_existing_hash:
+                try:
+                    # if source hash not computed, compute quick sha256 now (soft bumper if fails)
+                    sh = r.sha256
+                    if not sh:
+                        sh = sha256_file(src)
+                    dh = sha256_file(dst)
+                    if sh == dh:
+                        actions.append(PlannedAction("SKIP", r.path, str(dst), r.bucket, "dst_exists_same_hash", r.size))
+                        continue
+                    else:
+                        bumper(bumpers_list, "DST_EXISTS_HASH_DIFF", "warn", f"{src} -> {dst}", "Destination exists with different hash; leaving in place")
+                        actions.append(PlannedAction("SKIP", r.path, str(dst), r.bucket, "dst_exists_hash_diff", r.size))
+                        continue
+                except Exception as e:
+                    bumper(bumpers_list, "DST_EXISTS_VERIFY_FAIL", "soft", f"{src} -> {dst}", "Failed verifying existing destination", str(e))
+                    actions.append(PlannedAction("SKIP", r.path, str(dst), r.bucket, "dst_exists_verify_fail", r.size))
+                    continue
+            actions.append(PlannedAction("SKIP", r.path, str(dst), r.bucket, "dst_exists_skip_existing", r.size))
+            continue
+
+        actions.append(PlannedAction("MOVE", r.path, str(dst), r.bucket, f"{r.rule_id}:{r.rule_reason}", r.size))
+    return actions
+
+
+# -------------------------
+# Apply plan (transactional logs, resumable)
+# -------------------------
+def apply_plan(actions: List[PlannedAction], bumpers_list: List[Bumper], do_copy: bool, dry_run: bool, apply_dir: Path, halt_on_hard: bool) -> Dict[str, int]:
+    safe_mkdir(apply_dir)
+    log_path = apply_dir / "apply_log.jsonl"
+
+    moved = 0
+    copied = 0
+    skipped = 0
+    failed = 0
+
+    # hard bumpers check (optional)
+    if halt_on_hard:
+        hard = [b for b in bumpers_list if b.severity == "hard"]
+        if hard:
+            bumper(bumpers_list, "HALT_ON_HARD", "hard", "apply_plan", "Halting apply due to hard bumpers", detail=f"count={len(hard)}")
+            return {"moved": 0, "copied": 0, "skipped": 0, "failed": 0}
+
+    for a in actions:
+        if a.action == "SKIP":
+            skipped += 1
+            append_jsonl(log_path, {"ts": now_iso(), "action": "SKIP", "src": a.src, "dst": a.dst, "reason": a.reason})
+            continue
+
+        src = Path(a.src)
+        dst = Path(a.dst)
+
+        try:
+            safe_mkdir(dst.parent)
+            if dry_run:
+                if do_copy:
+                    copied += 1
+                    append_jsonl(log_path, {"ts": now_iso(), "action": "DRY_COPY", "src": a.src, "dst": a.dst, "bucket": a.bucket})
+                else:
+                    moved += 1
+                    append_jsonl(log_path, {"ts": now_iso(), "action": "DRY_MOVE", "src": a.src, "dst": a.dst, "bucket": a.bucket})
+                continue
+
+            if dst.exists():
+                bumper(bumpers_list, "DST_EXISTS", "warn", f"{a.src} -> {a.dst}", "Destination exists; skipping")
+                skipped += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "SKIP_DST_EXISTS", "src": a.src, "dst": a.dst})
+                continue
+
+            if do_copy:
+                shutil.copy2(str(src), str(dst))
+                copied += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "COPY", "src": a.src, "dst": a.dst, "bucket": a.bucket})
+            else:
+                shutil.move(str(src), str(dst))
+                moved += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "MOVE", "src": a.src, "dst": a.dst, "bucket": a.bucket})
+
+        except Exception as e:
+            failed += 1
+            bumper(bumpers_list, "APPLY_FAIL", "warn", f"{a.src} -> {a.dst}", "Move/copy failed", str(e))
+            append_jsonl(log_path, {"ts": now_iso(), "action": "FAIL", "src": a.src, "dst": a.dst, "error": str(e)})
+
+    stats = {"moved": moved, "copied": copied, "skipped": skipped, "failed": failed}
+    write_json(apply_dir / "apply_stats.json", stats)
+    return stats
+
+
+# -------------------------
+# Dedup + version consolidation
+# -------------------------
+def dedupe_groups(recs: List[FileRecord]) -> Dict[str, List[FileRecord]]:
+    groups: Dict[str, List[FileRecord]] = {}
+    for r in recs:
+        if r.sha256:
+            k = f"sha256:{r.sha256}"
+        elif r.quick_sig:
+            k = f"qs:{r.size}:{r.quick_sig}"
+        else:
+            k = f"path:{r.path}"
+        groups.setdefault(k, []).append(r)
+    return {k: v for k, v in groups.items() if len(v) > 1 and (k.startswith("sha256:") or k.startswith("qs:"))}
+
+
+def choose_canonical(paths: List[FileRecord]) -> FileRecord:
+    def score(r: FileRecord) -> Tuple[float, float, float]:
+        vs = r.version_score or 0.0
+        name = Path(r.path).name.lower()
+        bonus = 0.0
+        if "final" in name:
+            bonus += 3.0
+        if "canonical" in name:
+            bonus += 2.0
+        if "master" in name:
+            bonus += 1.5
+        return (vs + bonus, r.mtime, r.size)
+    return sorted(paths, key=score, reverse=True)[0]
+
+
+def build_duplicates_summary(groups: Dict[str, List[FileRecord]]) -> Dict[str, dict]:
+    out: Dict[str, dict] = {}
+    for k, members in groups.items():
+        canon = choose_canonical(members)
+        out[k] = {
+            "key": k,
+            "count": len(members),
+            "canonical": canon.path,
+            "members": [m.path for m in members],
+            "sha256": canon.sha256 or "",
+            "size": canon.size,
+        }
+    return out
+
+
+def group_versions(recs: List[FileRecord]) -> Dict[str, List[FileRecord]]:
+    fam: Dict[str, List[FileRecord]] = {}
+    for r in recs:
+        if r.version_family:
+            fam.setdefault(r.version_family, []).append(r)
+    return {k: v for k, v in fam.items() if len(v) > 1}
+
+
+def build_versions_summary(fams: Dict[str, List[FileRecord]]) -> Dict[str, dict]:
+    out: Dict[str, dict] = {}
+    for k, members in fams.items():
+        canon = choose_canonical(members)
+        out[k] = {"family": k, "count": len(members), "canonical": canon.path, "members": [m.path for m in members]}
+    return out
+
+
+# -------------------------
+# ZIP inventory
+# -------------------------
+def inventory_zip(path: Path, bumpers_list: List[Bumper], max_members: int = 50000, hash_members: bool = False) -> List[dict]:
+    rows: List[dict] = []
+    try:
+        with zipfile.ZipFile(path, "r") as z:
+            names = z.namelist()
+            if len(names) > max_members:
+                bumper(bumpers_list, "ZIP_TOO_LARGE", "warn", str(path), f"Zip has {len(names)} members; truncating to {max_members}")
+                names = names[:max_members]
+            for nm in names:
+                try:
+                    info = z.getinfo(nm)
+                    row = {
+                        "zip_path": str(path),
+                        "member": nm,
+                        "size": int(info.file_size),
+                        "mtime": f"{info.date_time[0]:04d}-{info.date_time[1]:02d}-{info.date_time[2]:02d}T{info.date_time[3]:02d}:{info.date_time[4]:02d}:{info.date_time[5]:02d}",
+                        "is_dir": nm.endswith("/"),
+                        "sha256": "",
+                    }
+                    if hash_members and not row["is_dir"]:
+                        with z.open(nm, "r") as f:
+                            h = hashlib.sha256()
+                            while True:
+                                b = f.read(1024 * 1024)
+                                if not b:
+                                    break
+                                h.update(b)
+                            row["sha256"] = h.hexdigest()
+                    rows.append(row)
+                except Exception as e:
+                    bumper(bumpers_list, "ZIP_MEMBER_FAIL", "soft", f"{path}::{nm}", "Failed reading zip member", str(e))
+    except Exception as e:
+        bumper(bumpers_list, "ZIP_OPEN_FAIL", "warn", str(path), "Failed opening zip", str(e))
+    return rows
+
+
+# -------------------------
+# OCR queue heuristic (conservative)
+# -------------------------
+def needs_ocr_pdf(path: Path) -> bool:
+    try:
+        raw = path.read_bytes()[:250_000]
+        letters = sum(1 for b in raw if 65 <= b <= 122)
+        if letters < 450:
+            return True
+    except Exception:
+        return False
+    return False
+
+
+# -------------------------
+# Content scan + adversarial hit normalization
+# -------------------------
+def load_terms_from_file(p: Path, cap: int) -> List[str]:
+    out: List[str] = []
+    if not p.exists():
+        return out
+    for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+        t = line.strip()
+        if t:
+            out.append(t)
+        if len(out) >= cap:
+            break
+    return out
+
+
+def content_read_text_best_effort(path: Path, max_bytes: int) -> str:
+    raw = path.read_bytes()
+    if len(raw) > max_bytes:
+        raw = raw[:max_bytes]
+    return raw.decode("utf-8", errors="ignore")
+
+
+def find_term_hits(text: str, term: str, max_hits: int = 25) -> List[int]:
+    hits: List[int] = []
+    lower = text.lower()
+    t = term.lower()
+    start = 0
+    while len(hits) < max_hits:
+        i = lower.find(t, start)
+        if i == -1:
+            break
+        hits.append(i)
+        start = i + max(1, len(t))
+    return hits
+
+
+def make_eaid(path: str, offset: int, term: str) -> str:
+    base = f"{path}|{offset}|{term}"
+    return "EAID_" + hashlib.sha1(base.encode("utf-8", errors="ignore")).hexdigest()[:16]
+
+
+def content_scan_and_adversarial(
+    recs: List[FileRecord],
+    bumpers_list: List[Bumper],
+    include_exts: Set[str],
+    max_bytes: int,
+    lexicon: Dict[str, List[str]],
+    extra_terms: List[str],
+) -> Tuple[dict, List[dict], List[dict]]:
+    """
+    Returns:
+      summary, content_flags_rows, adversarial_hits_rows
+    """
+    content_flags_rows: List[dict] = []
+    adversarial_hits_rows: List[dict] = []
+    scanned = 0
+    matched_files = 0
+
+    # Build flattened term list per category (plus extras under CUSTOM)
+    cat_terms: Dict[str, List[str]] = {}
+    for cat, terms in lexicon.items():
+        cat_terms[cat] = list(terms)
+    if extra_terms:
+        cat_terms.setdefault("CUSTOM", [])
+        cat_terms["CUSTOM"].extend(extra_terms)
+
+    # de-dup terms per category
+    for cat in list(cat_terms.keys()):
+        seen = set()
+        uniq = []
+        for t in cat_terms[cat]:
+            tl = t.lower().strip()
+            if not tl or tl in seen:
+                continue
+            seen.add(tl)
+            uniq.append(t)
+        cat_terms[cat] = uniq
+
+    for r in recs:
+        p = Path(r.path)
+        if p.suffix.lower() not in include_exts:
+            continue
+        scanned += 1
+        try:
+            text = content_read_text_best_effort(p, max_bytes=max_bytes)
+        except Exception as e:
+            bumper(bumpers_list, "CONTENT_READ_FAIL", "soft", r.path, "Content read failed", str(e))
+            continue
+
+        file_any = False
+        file_flags: List[dict] = []
+        for cat, terms in cat_terms.items():
+            for t in terms:
+                for idx in find_term_hits(text, t, max_hits=20):
+                    file_any = True
+                    excerpt = text[max(0, idx - 90): idx + len(t) + 90].replace("\n", " ")
+                    file_flags.append({"category": cat, "term": t, "offset": idx, "excerpt": excerpt})
+                    adversarial_hits_rows.append({
+                        "eaid": make_eaid(r.path, idx, t),
+                        "path": r.path,
+                        "bucket": r.bucket,
+                        "ext": r.ext,
+                        "category": cat,
+                        "term": t,
+                        "offset": idx,
+                        "excerpt": excerpt,
+                        "integrity_key": integrity_key(p),
+                        "resolver": {"path": r.path, "offset": idx, "hint": "byte-offset in decoded utf-8 best-effort sample"},
+                    })
+        if file_any:
+            matched_files += 1
+            content_flags_rows.append({"path": r.path, "bucket": r.bucket, "ext": r.ext, "matches": file_flags})
+
+    summary = {"scanned_files": scanned, "matched_files": matched_files}
+    return summary, content_flags_rows, adversarial_hits_rows
+
+
+# -------------------------
+# Cleanup empty folders (plan/apply optional)
+# -------------------------
+def plan_empty_folder_cleanup(roots: List[Path], bumpers_list: List[Bumper]) -> List[dict]:
+    """
+    Plan: list empty directories under roots excluding system paths.
+    """
+    empties: List[dict] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+            dp = Path(dirpath)
+            if is_system_path(dp):
+                continue
+            try:
+                # Consider empty if no files and no subdirs (after traversal)
+                if not list(dp.iterdir()):
+                    empties.append({"path": str(dp), "reason": "empty_dir"})
+            except Exception as e:
+                bumper(bumpers_list, "EMPTY_CHECK_FAIL", "soft", str(dp), "Failed checking emptiness", str(e))
+    return empties
+
+
+def apply_empty_folder_cleanup(plan: List[dict], bumpers_list: List[Bumper], dry_run: bool, log_path: Path) -> Dict[str, int]:
+    removed = 0
+    skipped = 0
+    failed = 0
+    for row in plan:
+        p = Path(row["path"])
+        try:
+            if not p.exists():
+                skipped += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "SKIP_MISSING_DIR", "path": str(p)})
+                continue
+            if list(p.iterdir()):
+                skipped += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "SKIP_NOT_EMPTY", "path": str(p)})
+                continue
+            if dry_run:
+                removed += 1
+                append_jsonl(log_path, {"ts": now_iso(), "action": "DRY_REMOVE_DIR", "path": str(p)})
+                continue
+            p.rmdir()
+            removed += 1
+            append_jsonl(log_path, {"ts": now_iso(), "action": "REMOVE_DIR", "path": str(p)})
+        except Exception as e:
+            failed += 1
+            bumper(bumpers_list, "REMOVE_DIR_FAIL", "warn", str(p), "Failed removing empty dir", str(e))
+            append_jsonl(log_path, {"ts": now_iso(), "action": "FAIL_REMOVE_DIR", "path": str(p), "error": str(e)})
+    return {"removed": removed, "skipped": skipped, "failed": failed}
+
+
+# ============================
+# Graph model + pipeline + virtualization + physics + ERD
+# ============================
+def read_jsonl(path: Path, max_rows: Optional[int] = None) -> List[dict]:
+    rows: List[dict] = []
+    if not path.exists():
+        return rows
+    with path.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            if max_rows is not None and i >= max_rows:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                continue
+    return rows
+
+
+def _node_id(label: str, key: str) -> str:
+    return f"{label}::{key}"
+
+
+def _edge_id(edge_type: str, start_id: str, end_id: str, salt: str = "") -> str:
+    base = f"{edge_type}|{start_id}|{end_id}|{salt}"
+    return hashlib.sha1(base.encode("utf-8", errors="ignore")).hexdigest()[:20]
+
+
+def build_erd_superset_schema() -> Dict[str, Any]:
+    entities = [
+        {"name": "Run", "pk": "run_id", "fields": ["run_id"]},
+        {"name": "Drive", "pk": "drive", "fields": ["drive"]},
+        {"name": "Folder", "pk": "folder_id", "fields": ["folder_id", "path"]},
+        {"name": "Bucket", "pk": "bucket_id", "fields": ["bucket_id", "desc"]},
+        {"name": "File", "pk": "file_id", "fields": ["file_id", "path", "ext", "size", "mtime", "sha256", "quick_sig", "version_family", "version_score", "rule_id", "rule_reason", "notes"]},
+        {"name": "Action", "pk": "action_id", "fields": ["action_id", "action", "src", "dst", "reason", "bucket", "size"]},
+        {"name": "Bumper", "pk": "bumper_id", "fields": ["bumper_id", "id", "ts", "severity", "where", "msg", "mv", "detail"]},
+        {"name": "DuplicateGroup", "pk": "group_id", "fields": ["group_id", "count", "canonical", "sha256", "size"]},
+        {"name": "VersionFamily", "pk": "family", "fields": ["family", "count", "canonical"]},
+        {"name": "ZipMember", "pk": "zip_member_id", "fields": ["zip_member_id", "zip_path", "member", "size", "mtime", "is_dir", "sha256"]},
+        {"name": "ContentFlag", "pk": "flag_id", "fields": ["flag_id", "path", "bucket", "ext", "matches"]},
+
+        # Superset overlays (schema-first)
+        {"name": "Court", "pk": "court_id", "fields": ["court_id", "name", "jurisdiction", "level"]},
+        {"name": "Case", "pk": "case_id", "fields": ["case_id", "caption", "court_id", "docket_no", "case_type", "opened", "closed"]},
+        {"name": "Party", "pk": "party_id", "fields": ["party_id", "name", "role", "side"]},
+        {"name": "Filing", "pk": "filing_id", "fields": ["filing_id", "case_id", "date_filed", "title", "doc_type", "roa_no"]},
+        {"name": "Order", "pk": "order_id", "fields": ["order_id", "case_id", "date_entered", "title", "signed_by", "text_hash"]},
+        {"name": "Transcript", "pk": "transcript_id", "fields": ["transcript_id", "case_id", "hearing_date", "reporter", "text_hash"]},
+        {"name": "Exhibit", "pk": "exhibit_id", "fields": ["exhibit_id", "case_id", "label", "party", "description", "source_file_id", "integrity_key"]},
+        {"name": "Event", "pk": "event_id", "fields": ["event_id", "case_id", "ts", "event_type", "summary", "source_file_id"]},
+        {"name": "Authority", "pk": "authority_id", "fields": ["authority_id", "type", "cite", "pinpoint", "snapshot_id"]},
+        {"name": "Form", "pk": "form_id", "fields": ["form_id", "name", "jurisdiction", "url", "version"]},
+        {"name": "MisconductVector", "pk": "mv_id", "fields": ["mv_id", "category", "signals", "proof", "remedies"]},
+        {"name": "Remedy", "pk": "remedy_id", "fields": ["remedy_id", "name", "vehicle", "standard", "authority_id"]},
+        {"name": "Claim", "pk": "claim_id", "fields": ["claim_id", "case_id", "theory", "elements", "authority_id"]},
+    ]
+
+    relationships = [
+        {"type": "RUN_SAW", "from": "Run", "to": "File"},
+        {"type": "RUN_PLANNED", "from": "Run", "to": "Action"},
+        {"type": "RUN_BUMPER", "from": "Run", "to": "Bumper"},
+        {"type": "RUN_DUPGROUP", "from": "Run", "to": "DuplicateGroup"},
+        {"type": "RUN_VERSIONFAM", "from": "Run", "to": "VersionFamily"},
+        {"type": "IN_BUCKET", "from": "File", "to": "Bucket"},
+        {"type": "ON_DRIVE", "from": "File", "to": "Drive"},
+        {"type": "IN_FOLDER", "from": "File", "to": "Folder"},
+        {"type": "FOLDER_ON_DRIVE", "from": "Folder", "to": "Drive"},
+        {"type": "ACTION_ON", "from": "Action", "to": "File"},
+        {"type": "BUMPER_ON", "from": "Bumper", "to": "File"},
+        {"type": "DUP_MEMBER", "from": "DuplicateGroup", "to": "File"},
+        {"type": "VF_MEMBER", "from": "VersionFamily", "to": "File"},
+        {"type": "ZIP_CONTAINS", "from": "File", "to": "ZipMember"},
+        {"type": "FLAG_ON", "from": "ContentFlag", "to": "File"},
+
+        # Overlay
+        {"type": "CASE_IN_COURT", "from": "Case", "to": "Court"},
+        {"type": "PARTY_IN_CASE", "from": "Party", "to": "Case"},
+        {"type": "FILING_IN_CASE", "from": "Filing", "to": "Case"},
+        {"type": "ORDER_IN_CASE", "from": "Order", "to": "Case"},
+        {"type": "TRANSCRIPT_IN_CASE", "from": "Transcript", "to": "Case"},
+        {"type": "EXHIBIT_IN_CASE", "from": "Exhibit", "to": "Case"},
+        {"type": "EVENT_IN_CASE", "from": "Event", "to": "Case"},
+        {"type": "EXHIBIT_SOURCE_FILE", "from": "Exhibit", "to": "File"},
+        {"type": "EVENT_SOURCE_FILE", "from": "Event", "to": "File"},
+        {"type": "FILING_SOURCE_FILE", "from": "Filing", "to": "File"},
+        {"type": "CLAIM_IN_CASE", "from": "Claim", "to": "Case"},
+        {"type": "CLAIM_AUTHORITY", "from": "Claim", "to": "Authority"},
+        {"type": "REMEDY_AUTHORITY", "from": "Remedy", "to": "Authority"},
+        {"type": "USES_FORM", "from": "Filing", "to": "Form"},
+        {"type": "ASSERTS_MV", "from": "Event", "to": "MisconductVector"},
+        {"type": "SEEKS_REMEDY", "from": "Claim", "to": "Remedy"},
+    ]
+
+    return {"name": "ERD_SUPERSET_FED_BLUEPRINT", "version": APP_VER, "entities": entities, "relationships": relationships}
+
+
+def build_graph_model(
+    run_id: str,
+    records: List[FileRecord],
+    actions: List[PlannedAction],
+    bumpers_list: List[Bumper],
+    dup_summary: Dict[str, dict],
+    versions_summary: Dict[str, dict],
+    zip_rows: Optional[List[dict]],
+    content_flags: Optional[List[dict]],
+) -> Tuple[List[dict], List[dict], Dict[str, Any]]:
+    nodes: Dict[str, dict] = {}
+    edges: Dict[str, dict] = {}
+
+    run_node_id = _node_id("Run", run_id)
+    nodes[run_node_id] = {"node_id": run_node_id, "label": "Run", "props": {"run_id": run_id}}
+
+    for bid, desc in DEFAULT_BUCKETS:
+        nid = _node_id("Bucket", bid)
+        nodes[nid] = {"node_id": nid, "label": "Bucket", "props": {"bucket_id": bid, "desc": desc}}
+
+    # Drives + folders + files
+    for r in records:
+        file_id = stable_id_for_path(r.path)
+        f_nid = _node_id("File", file_id)
+        nodes[f_nid] = {"node_id": f_nid, "label": "File", "props": {
+            "file_id": file_id,
+            "path": r.path,
+            "ext": r.ext,
+            "size": r.size,
+            "mtime": r.mtime,
+            "sha256": r.sha256 or "",
+            "quick_sig": r.quick_sig or "",
+            "version_family": r.version_family or "",
+            "version_score": float(r.version_score or 0.0),
+            "rule_id": r.rule_id,
+            "rule_reason": r.rule_reason,
+            "notes": r.notes or "",
+        }}
+
+        edges[_edge_id("RUN_SAW", run_node_id, f_nid)] = {"edge_id": _edge_id("RUN_SAW", run_node_id, f_nid), "type": "RUN_SAW", "start_id": run_node_id, "end_id": f_nid, "props": {}}
+        b_nid = _node_id("Bucket", r.bucket)
+        edges[_edge_id("IN_BUCKET", f_nid, b_nid)] = {"edge_id": _edge_id("IN_BUCKET", f_nid, b_nid), "type": "IN_BUCKET", "start_id": f_nid, "end_id": b_nid, "props": {}}
+
+        drv = r.drive or "ROOT"
+        d_nid = _node_id("Drive", drv)
+        if d_nid not in nodes:
+            nodes[d_nid] = {"node_id": d_nid, "label": "Drive", "props": {"drive": drv}}
+        edges[_edge_id("ON_DRIVE", f_nid, d_nid)] = {"edge_id": _edge_id("ON_DRIVE", f_nid, d_nid), "type": "ON_DRIVE", "start_id": f_nid, "end_id": d_nid, "props": {}}
+
+        parent = str(Path(r.path).parent)
+        folder_id = stable_id_for_path(parent)
+        fol_nid = _node_id("Folder", folder_id)
+        if fol_nid not in nodes:
+            nodes[fol_nid] = {"node_id": fol_nid, "label": "Folder", "props": {"folder_id": folder_id, "path": parent}}
+        edges[_edge_id("IN_FOLDER", f_nid, fol_nid)] = {"edge_id": _edge_id("IN_FOLDER", f_nid, fol_nid), "type": "IN_FOLDER", "start_id": f_nid, "end_id": fol_nid, "props": {}}
+        edges[_edge_id("FOLDER_ON_DRIVE", fol_nid, d_nid)] = {"edge_id": _edge_id("FOLDER_ON_DRIVE", fol_nid, d_nid), "type": "FOLDER_ON_DRIVE", "start_id": fol_nid, "end_id": d_nid, "props": {}}
+
+    # Actions
+    for a in actions:
+        act_id = stable_id_for_path(f"{a.src}->{a.dst}|{a.action}|{a.reason}")
+        act_nid = _node_id("Action", act_id)
+        nodes[act_nid] = {"node_id": act_nid, "label": "Action", "props": {
+            "action_id": act_id, "action": a.action, "src": a.src, "dst": a.dst,
+            "reason": a.reason, "bucket": a.bucket, "size": a.size
+        }}
+        edges[_edge_id("RUN_PLANNED", run_node_id, act_nid)] = {"edge_id": _edge_id("RUN_PLANNED", run_node_id, act_nid), "type": "RUN_PLANNED", "start_id": run_node_id, "end_id": act_nid, "props": {}}
+        src_file_id = stable_id_for_path(a.src)
+        f_nid = _node_id("File", src_file_id)
+        edges[_edge_id("ACTION_ON", act_nid, f_nid)] = {"edge_id": _edge_id("ACTION_ON", act_nid, f_nid), "type": "ACTION_ON", "start_id": act_nid, "end_id": f_nid, "props": {}}
+
+    # Bumpers
+    for b in bumpers_list:
+        bkey = stable_id_for_path(b.ts + "|" + b.id + "|" + b.where + "|" + (b.msg or ""))
+        b_nid = _node_id("Bumper", bkey)
+        nodes[b_nid] = {"node_id": b_nid, "label": "Bumper", "props": {
+            "bumper_id": bkey, "id": b.id, "ts": b.ts, "severity": b.severity, "where": b.where,
+            "msg": b.msg, "mv": b.mv or "", "detail": b.detail or ""
+        }}
+        edges[_edge_id("RUN_BUMPER", run_node_id, b_nid)] = {"edge_id": _edge_id("RUN_BUMPER", run_node_id, b_nid), "type": "RUN_BUMPER", "start_id": run_node_id, "end_id": b_nid, "props": {}}
+
+        # Link bumper to known file if possible
+        known_paths = {r.path for r in records}
+        fp = None
+        if b.where in known_paths:
+            fp = b.where
+        elif " -> " in b.where:
+            left = b.where.split(" -> ")[0].strip()
+            if left in known_paths:
+                fp = left
+        elif "::" in b.where:
+            left = b.where.split("::")[0].strip()
+            if left in known_paths:
+                fp = left
+        if fp:
+            f_nid = _node_id("File", stable_id_for_path(fp))
+            edges[_edge_id("BUMPER_ON", b_nid, f_nid)] = {"edge_id": _edge_id("BUMPER_ON", b_nid, f_nid), "type": "BUMPER_ON", "start_id": b_nid, "end_id": f_nid, "props": {}}
+
+    # Duplicate groups
+    for gid, g in dup_summary.items():
+        dg_nid = _node_id("DuplicateGroup", stable_id_for_path(gid))
+        nodes[dg_nid] = {"node_id": dg_nid, "label": "DuplicateGroup", "props": {
+            "group_id": gid, "count": int(g.get("count", 0)), "canonical": g.get("canonical", ""),
+            "sha256": g.get("sha256", ""), "size": int(g.get("size", 0))
+        }}
+        edges[_edge_id("RUN_DUPGROUP", run_node_id, dg_nid)] = {"edge_id": _edge_id("RUN_DUPGROUP", run_node_id, dg_nid), "type": "RUN_DUPGROUP", "start_id": run_node_id, "end_id": dg_nid, "props": {}}
+        for mp in g.get("members", []):
+            f_nid = _node_id("File", stable_id_for_path(mp))
+            edges[_edge_id("DUP_MEMBER", dg_nid, f_nid, salt=mp)] = {"edge_id": _edge_id("DUP_MEMBER", dg_nid, f_nid, salt=mp), "type": "DUP_MEMBER", "start_id": dg_nid, "end_id": f_nid, "props": {}}
+
+    # Version families
+    for fam, g in versions_summary.items():
+        vf_nid = _node_id("VersionFamily", stable_id_for_path(fam))
+        nodes[vf_nid] = {"node_id": vf_nid, "label": "VersionFamily", "props": {
+            "family": fam, "count": int(g.get("count", 0)), "canonical": g.get("canonical", "")
+        }}
+        edges[_edge_id("RUN_VERSIONFAM", run_node_id, vf_nid)] = {"edge_id": _edge_id("RUN_VERSIONFAM", run_node_id, vf_nid), "type": "RUN_VERSIONFAM", "start_id": run_node_id, "end_id": vf_nid, "props": {}}
+        for mp in g.get("members", []):
+            f_nid = _node_id("File", stable_id_for_path(mp))
+            edges[_edge_id("VF_MEMBER", vf_nid, f_nid, salt=mp)] = {"edge_id": _edge_id("VF_MEMBER", vf_nid, f_nid, salt=mp), "type": "VF_MEMBER", "start_id": vf_nid, "end_id": f_nid, "props": {}}
+
+    # Zip members
+    if zip_rows:
+        for zr in zip_rows:
+            zpath = zr.get("zip_path", "")
+            member = zr.get("member", "")
+            zid = stable_id_for_path(zpath)
+            zf_nid = _node_id("File", zid)
+            mem_id = stable_id_for_path(zpath + "::" + member)
+            zm_nid = _node_id("ZipMember", mem_id)
+            nodes[zm_nid] = {"node_id": zm_nid, "label": "ZipMember", "props": {
+                "zip_member_id": mem_id, "zip_path": zpath, "member": member,
+                "size": int(zr.get("size", 0)), "mtime": zr.get("mtime", ""),
+                "is_dir": bool(zr.get("is_dir", False)), "sha256": zr.get("sha256", "")
+            }}
+            edges[_edge_id("ZIP_CONTAINS", zf_nid, zm_nid, salt=member)] = {"edge_id": _edge_id("ZIP_CONTAINS", zf_nid, zm_nid, salt=member), "type": "ZIP_CONTAINS", "start_id": zf_nid, "end_id": zm_nid, "props": {}}
+
+    # Content flags
+    if content_flags:
+        for cf in content_flags:
+            p = cf.get("path", "")
+            if not p:
+                continue
+            fid = stable_id_for_path(p)
+            f_nid = _node_id("File", fid)
+            flag_id = stable_id_for_path(p + "|" + json.dumps(cf.get("matches", []), sort_keys=True))
+            c_nid = _node_id("ContentFlag", flag_id)
+            nodes[c_nid] = {"node_id": c_nid, "label": "ContentFlag", "props": {
+                "flag_id": flag_id, "path": p, "bucket": cf.get("bucket", ""), "ext": cf.get("ext", ""),
+                "matches": cf.get("matches", [])
+            }}
+            edges[_edge_id("FLAG_ON", c_nid, f_nid)] = {"edge_id": _edge_id("FLAG_ON", c_nid, f_nid), "type": "FLAG_ON", "start_id": c_nid, "end_id": f_nid, "props": {}}
+
+    schema = build_erd_superset_schema()
+    return list(nodes.values()), list(edges.values()), schema
+
+
+def compute_graph_metrics(nodes: List[dict], edges: List[dict]) -> Dict[str, Any]:
+    node_ids = [n["node_id"] for n in nodes]
+    idx = {nid: i for i, nid in enumerate(node_ids)}
+    n = len(node_ids)
+    out_deg = [0] * n
+    und = [[] for _ in range(n)]
+    out_adj = [[] for _ in range(n)]
+    out_count = [0] * n
+
+    for e in edges:
+        u = e["start_id"]
+        v = e["end_id"]
+        if u in idx and v in idx:
+            ui = idx[u]
+            vi = idx[v]
+            out_deg[ui] += 1
+            und[ui].append(vi)
+            und[vi].append(ui)
+            out_adj[ui].append(vi)
+            out_count[ui] += 1
+
+    # Components
+    comp_id = [-1] * n
+    comps: List[List[int]] = []
+    cid = 0
+    for i in range(n):
+        if comp_id[i] != -1:
+            continue
+        q = [i]
+        comp_id[i] = cid
+        comp = [i]
+        while q:
+            cur = q.pop()
+            for nb in und[cur]:
+                if comp_id[nb] == -1:
+                    comp_id[nb] = cid
+                    q.append(nb)
+                    comp.append(nb)
+        comps.append(comp)
+        cid += 1
+
+    # PageRank
+    pr = [1.0 / n] * n if n else []
+    d = 0.85
+    for _ in range(30):
+        new = [(1.0 - d) / n] * n if n else []
+        for ui in range(n):
+            if out_count[ui] == 0:
+                share = d * pr[ui] / n if n else 0
+                for j in range(n):
+                    new[j] += share
+            else:
+                share = d * pr[ui] / out_count[ui]
+                for vi in out_adj[ui]:
+                    new[vi] += share
+        pr = new
+
+    top_pr = sorted([(node_ids[i], pr[i]) for i in range(n)], key=lambda x: -x[1])[:25]
+    top_deg = sorted([(node_ids[i], out_deg[i]) for i in range(n)], key=lambda x: -x[1])[:25]
+    comp_sizes = sorted([len(c) for c in comps], reverse=True)[:25]
+
+    return {
+        "n_nodes": n,
+        "n_edges": len(edges),
+        "components": {"count": len(comps), "largest_sizes": comp_sizes},
+        "top_pagerank": [{"node_id": nid, "pagerank": score} for nid, score in top_pr],
+        "top_out_degree": [{"node_id": nid, "out_degree": deg} for nid, deg in top_deg],
+    }
+
+
+def math_sin(x: float) -> float:
+    import math
+    return math.sin(x)
+
+
+def math_cos(x: float) -> float:
+    import math
+    return math.cos(x)
+
+
+def physics_layout(
+    nodes: List[dict],
+    edges: List[dict],
+    mode: str,
+    bumpers_list: List[Bumper],
+    seed: int = 1337,
+    iterations: int = 400,
+) -> Dict[str, Tuple[float, float]]:
+    """
+    Deterministic layout:
+      fast: degree-based radial placement
+      full: numpy force simulation if available; else degrades to grid approximation
+      grid: dependency-free approximate repulsion (bin grid)
+    """
+    import random
+    random.seed(seed)
+
+    node_ids = [n["node_id"] for n in nodes]
+    n = len(node_ids)
+    if n == 0:
+        return {}
+
+    # degrees
+    deg = {nid: 0 for nid in node_ids}
+    for e in edges:
+        deg[e["start_id"]] = deg.get(e["start_id"], 0) + 1
+        deg[e["end_id"]] = deg.get(e["end_id"], 0) + 1
+
+    if mode == "off":
+        return {nid: (0.0, 0.0) for nid in node_ids}
+
+    if mode == "fast":
+        max_deg = max(deg.values()) if deg else 1
+        out: Dict[str, Tuple[float, float]] = {}
+        for i, nid in enumerate(node_ids):
+            a = (i * 2.0 * 3.1415926535) / max(1, n)
+            r = 0.25 + 0.75 * (deg.get(nid, 0) / max_deg)
+            jitter = 0.03 * (random.random() - 0.5)
+            out[nid] = (r * (1.0 + jitter) * float(math_cos(a)), r * (1.0 + jitter) * float(math_sin(a)))
+        return out
+
+    if mode == "full":
+        if n > 2500:
+            bumper(bumpers_list, "PHYSICS-DEGRADED", "soft", "physics_layout", f"n_nodes={n} too large for full; using grid")
+            mode = "grid"
+        else:
+            try:
+                import numpy as np
+                idx = {nid: i for i, nid in enumerate(node_ids)}
+                pos = np.random.RandomState(seed).randn(n, 2).astype(np.float64) * 0.08
+                vel = np.zeros((n, 2), dtype=np.float64)
+
+                el = []
+                for e in edges:
+                    u = e["start_id"]
+                    v = e["end_id"]
+                    if u in idx and v in idx and u != v:
+                        el.append((idx[u], idx[v]))
+                if not el:
+                    return {nid: (float(pos[i, 0]), float(pos[i, 1])) for nid, i in idx.items()}
+                el = np.array(el, dtype=np.int32)
+
+                k_rep = 0.003
+                k_attr = 0.02
+                damp = 0.86
+                dt = 0.02
+
+                for _ in range(iterations):
+                    delta = pos[:, None, :] - pos[None, :, :]
+                    dist2 = (delta ** 2).sum(axis=2) + 1e-6
+                    inv = 1.0 / dist2
+                    rep = (delta * inv[:, :, None]).sum(axis=1) * k_rep
+
+                    u = el[:, 0]
+                    v = el[:, 1]
+                    dxy = pos[v] - pos[u]
+                    attr = np.zeros_like(pos)
+                    attr_u = dxy * k_attr
+                    np.add.at(attr, u, attr_u)
+                    np.add.at(attr, v, -attr_u)
+
+                    force = rep + attr
+                    vel = (vel + force * dt) * damp
+                    pos = pos + vel * dt
+                    pos = np.clip(pos, -1.6, 1.6)
+
+                return {node_ids[i]: (float(pos[i, 0]), float(pos[i, 1])) for i in range(n)}
+            except Exception:
+                bumper(bumpers_list, "PHYSICS-NO-NUMPY", "soft", "physics_layout", "numpy missing or failed; using grid")
+                mode = "grid"
+
+    # grid mode: bin-based approximate repulsion + edge attraction (dependency-free)
+    # Initialize fast positions
+    pos = {nid: (random.uniform(-0.5, 0.5), random.uniform(-0.5, 0.5)) for nid in node_ids}
+    # adjacency for attraction
+    adj: Dict[str, List[str]] = {}
+    for e in edges:
+        adj.setdefault(e["start_id"], []).append(e["end_id"])
+        adj.setdefault(e["end_id"], []).append(e["start_id"])
+
+    def clamp(x: float, lo: float, hi: float) -> float:
+        return lo if x < lo else hi if x > hi else x
+
+    cell = 0.15
+    k_rep = 0.008
+    k_attr = 0.010
+
+    for _ in range(min(iterations, 260)):
+        # Build grid bins
+        bins: Dict[Tuple[int, int], List[str]] = {}
+        for nid, (x, y) in pos.items():
+            gx = int(x / cell)
+            gy = int(y / cell)
+            bins.setdefault((gx, gy), []).append(nid)
+
+        # Repulsion approximate: only neighbor cells
+        new_pos = {}
+        for nid, (x, y) in pos.items():
+            gx = int(x / cell)
+            gy = int(y / cell)
+            fx = 0.0
+            fy = 0.0
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    for other in bins.get((gx + dx, gy + dy), []):
+                        if other == nid:
+                            continue
+                        ox, oy = pos[other]
+                        rx = x - ox
+                        ry = y - oy
+                        d2 = rx * rx + ry * ry + 1e-4
+                        inv = 1.0 / d2
+                        fx += rx * inv
+                        fy += ry * inv
+            # Attraction to neighbors
+            for other in adj.get(nid, []):
+                ox, oy = pos.get(other, (x, y))
+                fx += (ox - x) * k_attr
+                fy += (oy - y) * k_attr
+
+            nx = clamp(x + fx * k_rep, -1.5, 1.5)
+            ny = clamp(y + fy * k_rep, -1.5, 1.5)
+            new_pos[nid] = (nx, ny)
+        pos = new_pos
+
+    return pos
+
+
+def emit_virtual_graph_sqlite(db_path: Path, nodes: List[dict], edges: List[dict]) -> None:
+    import sqlite3
+    safe_mkdir(db_path.parent)
+    if db_path.exists():
+        db_path.unlink()
+
+    con = sqlite3.connect(str(db_path))
+    cur = con.cursor()
+    cur.execute("PRAGMA journal_mode=WAL;")
+    cur.execute("PRAGMA synchronous=NORMAL;")
+
+    cur.execute("""
+        CREATE TABLE nodes (
+            node_id TEXT PRIMARY KEY,
+            label TEXT NOT NULL,
+            props_json TEXT NOT NULL
+        );
+    """)
+    cur.execute("CREATE INDEX idx_nodes_label ON nodes(label);")
+
+    cur.execute("""
+        CREATE TABLE edges (
+            edge_id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            start_id TEXT NOT NULL,
+            end_id TEXT NOT NULL,
+            props_json TEXT NOT NULL
+        );
+    """)
+    cur.execute("CREATE INDEX idx_edges_type ON edges(type);")
+    cur.execute("CREATE INDEX idx_edges_start ON edges(start_id);")
+    cur.execute("CREATE INDEX idx_edges_end ON edges(end_id);")
+
+    cur.executemany(
+        "INSERT INTO nodes(node_id,label,props_json) VALUES(?,?,?)",
+        [(n["node_id"], n["label"], json.dumps(n.get("props", {}), ensure_ascii=False)) for n in nodes],
+    )
+    cur.executemany(
+        "INSERT INTO edges(edge_id,type,start_id,end_id,props_json) VALUES(?,?,?,?,?)",
+        [(e["edge_id"], e["type"], e["start_id"], e["end_id"], json.dumps(e.get("props", {}), ensure_ascii=False)) for e in edges],
+    )
+    con.commit()
+    con.close()
+
+
+def run_virtual_query(db_path: Path, name: str) -> Tuple[List[str], List[Tuple]]:
+    import sqlite3
+    con = sqlite3.connect(str(db_path))
+    cur = con.cursor()
+    q = DEFAULT_VIRTUAL_QUERY_PACK.get(name.strip(), "")
+    if not q:
+        con.close()
+        return (["error"], [(f"unknown query '{name}'. options: {', '.join(sorted(DEFAULT_VIRTUAL_QUERY_PACK.keys()))}",)])
+    cur.execute(q)
+    rows = cur.fetchall()
+    cols = [d[0] for d in cur.description] if cur.description else []
+    con.close()
+    return cols, rows
+
+
+def write_query_results(out_csv: Path, out_json: Path, cols: List[str], rows: List[Tuple]) -> None:
+    safe_mkdir(out_csv.parent)
+    with out_csv.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(cols)
+        for r in rows:
+            w.writerow(list(r))
+    write_json(out_json, {"columns": cols, "rows": [list(r) for r in rows]})
+
+
+def emit_html_graph_viewer(html_path: Path, nodes: List[dict], edges: List[dict], positions: Dict[str, Tuple[float, float]], title: str) -> None:
+    safe_mkdir(html_path.parent)
+
+    embed_nodes = []
+    for n in nodes:
+        props = n.get("props", {})
+        display = props.get("path") or props.get("bucket_id") or props.get("id") or props.get("family") or props.get("drive") or props.get("run_id") or n["node_id"]
+        embed_nodes.append({
+            "id": n["node_id"],
+            "label": n["label"],
+            "display": display,
+            "x": float(positions.get(n["node_id"], (0.0, 0.0))[0]),
+            "y": float(positions.get(n["node_id"], (0.0, 0.0))[1]),
+        })
+    embed_edges = [{"s": e["start_id"], "t": e["end_id"], "type": e["type"]} for e in edges]
+    payload = {"title": title, "nodes": embed_nodes, "edges": embed_edges}
+
+    html = f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>{title}</title>
+<style>
+body {{ margin:0; font-family: Arial, sans-serif; }}
+#top {{ padding:8px; background:#111; color:#eee; display:flex; gap:8px; align-items:center; }}
+#q {{ width:520px; padding:6px; }}
+#info {{ padding:8px; font-size:12px; color:#222; }}
+canvas {{ display:block; width:100vw; height:calc(100vh - 72px); background:#fff; }}
+.badge {{ padding:2px 6px; border:1px solid #444; border-radius:6px; font-size:12px; }}
+</style>
+</head>
+<body>
+<div id="top">
+  <span class="badge">Graph Viewer</span>
+  <span class="badge" id="stats"></span>
+  <input id="q" placeholder="search display/path/bucket (press Enter)"/>
+  <span class="badge" id="hit"></span>
+</div>
+<canvas id="c"></canvas>
+<div id="info"></div>
+<script>
+const DATA = {json.dumps(payload, ensure_ascii=False)};
+const canvas = document.getElementById('c');
+const ctx = canvas.getContext('2d');
+function resize() {{
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight - 72;
+}}
+window.addEventListener('resize', resize);
+resize();
+
+let scale = 220;
+let ox = canvas.width/2;
+let oy = canvas.height/2;
+let dragging = false;
+let lastx=0, lasty=0;
+
+canvas.addEventListener('mousedown', (e)=>{{ dragging=true; lastx=e.clientX; lasty=e.clientY; }});
+canvas.addEventListener('mouseup', ()=> dragging=false);
+canvas.addEventListener('mouseleave', ()=> dragging=false);
+canvas.addEventListener('mousemove', (e)=>{{
+  if(dragging) {{
+    ox += (e.clientX-lastx);
+    oy += (e.clientY-lasty);
+    lastx=e.clientX; lasty=e.clientY;
+    draw();
+  }}
+}});
+canvas.addEventListener('wheel', (e)=>{{
+  e.preventDefault();
+  const s = Math.exp(-e.deltaY*0.001);
+  scale *= s;
+  scale = Math.max(30, Math.min(900, scale));
+  draw();
+}}, {{ passive:false }});
+
+function worldToScreen(x,y) {{
+  return [ox + x*scale, oy + y*scale];
+}}
+
+const NMAP = new Map();
+for(const n of DATA.nodes) NMAP.set(n.id, n);
+document.getElementById('stats').textContent = `${{DATA.nodes.length}} nodes / ${{DATA.edges.length}} edges`;
+
+let HIT = null;
+function draw() {{
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  // edges
+  ctx.globalAlpha = 0.28;
+  ctx.strokeStyle = '#999';
+  for(const e of DATA.edges) {{
+    const a = NMAP.get(e.s);
+    const b = NMAP.get(e.t);
+    if(!a || !b) continue;
+    const [x1,y1] = worldToScreen(a.x, a.y);
+    const [x2,y2] = worldToScreen(b.x, b.y);
+    ctx.beginPath();
+    ctx.moveTo(x1,y1);
+    ctx.lineTo(x2,y2);
+    ctx.stroke();
+  }}
+  // nodes
+  ctx.globalAlpha = 1.0;
+  for(const n of DATA.nodes) {{
+    const [x,y] = worldToScreen(n.x, n.y);
+    ctx.fillStyle = (HIT && n.id===HIT.id) ? '#ff3b30' : '#111';
+    ctx.beginPath();
+    ctx.arc(x,y,3.2,0,Math.PI*2);
+    ctx.fill();
+  }}
+}}
+const q = document.getElementById('q');
+q.addEventListener('keydown', (e)=>{{
+  if(e.key !== 'Enter') return;
+  const term = q.value.trim().toLowerCase();
+  HIT = null;
+  if(!term) {{
+    document.getElementById('hit').textContent='';
+    document.getElementById('info').textContent='';
+    draw();
+    return;
+  }}
+  for(const n of DATA.nodes) {{
+    if(String(n.display).toLowerCase().includes(term) || String(n.label).toLowerCase().includes(term) || String(n.id).toLowerCase().includes(term)) {{
+      HIT = n; break;
+    }}
+  }}
+  if(HIT) {{
+    ox = canvas.width/2 - HIT.x*scale;
+    oy = canvas.height/2 - HIT.y*scale;
+    document.getElementById('hit').textContent = `hit: ${{HIT.label}}`;
+    document.getElementById('info').textContent = HIT.display;
+  }} else {{
+    document.getElementById('hit').textContent = 'no hit';
+    document.getElementById('info').textContent = '';
+  }}
+  draw();
+}});
+draw();
+</script>
+</body>
+</html>"""
+    html_path.write_text(html, encoding="utf-8")
+
+
+def emit_json_schema_nodes_edges(out_dir: Path) -> None:
+    safe_mkdir(out_dir)
+    node_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "VirtualGraphNode",
+        "type": "object",
+        "required": ["node_id", "label", "props"],
+        "properties": {
+            "node_id": {"type": "string"},
+            "label": {"type": "string"},
+            "props": {"type": "object"},
+        }
+    }
+    edge_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "VirtualGraphEdge",
+        "type": "object",
+        "required": ["edge_id", "type", "start_id", "end_id", "props"],
+        "properties": {
+            "edge_id": {"type": "string"},
+            "type": {"type": "string"},
+            "start_id": {"type": "string"},
+            "end_id": {"type": "string"},
+            "props": {"type": "object"},
+        }
+    }
+    write_json(out_dir / "nodes.schema.json", node_schema)
+    write_json(out_dir / "edges.schema.json", edge_schema)
+
+
+def emit_sqlite_ddl_overlay(out_dir: Path) -> None:
+    ddl = """
+-- ERD_SUPERSET_FED_BLUEPRINT overlay DDL (schema-first). Optional future ingestion.
+CREATE TABLE IF NOT EXISTS Court (court_id TEXT PRIMARY KEY, name TEXT, jurisdiction TEXT, level TEXT);
+CREATE TABLE IF NOT EXISTS Case_ (case_id TEXT PRIMARY KEY, caption TEXT, court_id TEXT, docket_no TEXT, case_type TEXT, opened TEXT, closed TEXT);
+CREATE TABLE IF NOT EXISTS Party (party_id TEXT PRIMARY KEY, name TEXT, role TEXT, side TEXT);
+CREATE TABLE IF NOT EXISTS Filing (filing_id TEXT PRIMARY KEY, case_id TEXT, date_filed TEXT, title TEXT, doc_type TEXT, roa_no TEXT);
+CREATE TABLE IF NOT EXISTS Order_ (order_id TEXT PRIMARY KEY, case_id TEXT, date_entered TEXT, title TEXT, signed_by TEXT, text_hash TEXT);
+CREATE TABLE IF NOT EXISTS Transcript (transcript_id TEXT PRIMARY KEY, case_id TEXT, hearing_date TEXT, reporter TEXT, text_hash TEXT);
+CREATE TABLE IF NOT EXISTS Exhibit (exhibit_id TEXT PRIMARY KEY, case_id TEXT, label TEXT, party TEXT, description TEXT, source_file_id TEXT, integrity_key TEXT);
+CREATE TABLE IF NOT EXISTS Event (event_id TEXT PRIMARY KEY, case_id TEXT, ts TEXT, event_type TEXT, summary TEXT, source_file_id TEXT);
+CREATE TABLE IF NOT EXISTS Authority (authority_id TEXT PRIMARY KEY, type TEXT, cite TEXT, pinpoint TEXT, snapshot_id TEXT);
+CREATE TABLE IF NOT EXISTS Form (form_id TEXT PRIMARY KEY, name TEXT, jurisdiction TEXT, url TEXT, version TEXT);
+CREATE TABLE IF NOT EXISTS MisconductVector (mv_id TEXT PRIMARY KEY, category TEXT, signals_json TEXT, proof_json TEXT, remedies_json TEXT);
+CREATE TABLE IF NOT EXISTS Remedy (remedy_id TEXT PRIMARY KEY, name TEXT, vehicle TEXT, standard TEXT, authority_id TEXT);
+CREATE TABLE IF NOT EXISTS Claim (claim_id TEXT PRIMARY KEY, case_id TEXT, theory TEXT, elements_json TEXT, authority_id TEXT);
+"""
+    write_text(out_dir / "ERD_SUPERSET_overlay_ddl.sql", ddl.strip() + "\n")
+
+
+def emit_erd_superset_files(out_dir: Path, schema: Dict[str, Any], bumpers_list: List[Bumper], physics_mode: str) -> None:
+    safe_mkdir(out_dir)
+    write_json(out_dir / "ERD_SUPERSET_FED_BLUEPRINT.json", schema)
+
+    md_lines: List[str] = []
+    md_lines.append("# ERD_SUPERSET_FED_BLUEPRINT")
+    md_lines.append("")
+    md_lines.append("## I. Version")
+    md_lines.append(f"- {schema.get('version','')}")
+    md_lines.append("")
+    md_lines.append("## II. Entities")
+    for ent in schema.get("entities", []):
+        md_lines.append(f"### {ent['name']}")
+        md_lines.append(f"- PK: `{ent['pk']}`")
+        md_lines.append(f"- Fields: {', '.join('`'+f+'`' for f in ent.get('fields', []))}")
+        md_lines.append("")
+    md_lines.append("## III. Relationships")
+    for rel in schema.get("relationships", []):
+        md_lines.append(f"- `{rel['type']}`: {rel['from']} → {rel['to']}")
+    write_text(out_dir / "ERD_SUPERSET_FED_BLUEPRINT.md", "\n".join(md_lines))
+
+    dot = []
+    dot.append("digraph ERD {")
+    dot.append("  rankdir=LR;")
+    dot.append("  node [shape=box, fontsize=10];")
+    for ent in schema.get("entities", []):
+        dot.append(f'  "{ent["name"]}";')
+    for rel in schema.get("relationships", []):
+        dot.append(f'  "{rel["from"]}" -> "{rel["to"]}" [label="{rel["type"]}"];')
+    dot.append("}")
+    write_text(out_dir / "ERD_SUPERSET_FED_BLUEPRINT.dot", "\n".join(dot))
+
+    emit_json_schema_nodes_edges(out_dir / "json_schema")
+    emit_sqlite_ddl_overlay(out_dir)
+
+    # HTML ERD viewer (entity graph)
+    if physics_mode != "off":
+        nlist = [{"node_id": _node_id("Entity", ent["name"]), "label": "Entity", "props": {"name": ent["name"]}} for ent in schema.get("entities", [])]
+        elist = []
+        for rel in schema.get("relationships", []):
+            s = _node_id("Entity", rel["from"])
+            t = _node_id("Entity", rel["to"])
+            elist.append({"edge_id": _edge_id(rel["type"], s, t), "type": rel["type"], "start_id": s, "end_id": t, "props": {}})
+        pos = physics_layout(nlist, elist, mode=("fast" if physics_mode == "grid" else physics_mode), bumpers_list=bumpers_list, seed=777, iterations=260)
+        emit_html_graph_viewer(out_dir / "ERD_SUPERSET_FED_BLUEPRINT.html", nlist, elist, pos, title="ERD_SUPERSET_FED_BLUEPRINT")
+
+
+def emit_csv_nodes_edges(out_dir: Path, nodes: List[dict], edges: List[dict]) -> None:
+    safe_mkdir(out_dir)
+    # nodes.csv
+    with (out_dir / "nodes.csv").open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["node_id", "label", "props_json"])
+        for n in nodes:
+            w.writerow([n["node_id"], n["label"], json.dumps(n.get("props", {}), ensure_ascii=False)])
+    # edges.csv
+    with (out_dir / "edges.csv").open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["edge_id", "type", "start_id", "end_id", "props_json"])
+        for e in edges:
+            w.writerow([e["edge_id"], e["type"], e["start_id"], e["end_id"], json.dumps(e.get("props", {}), ensure_ascii=False)])
+
+
+def emit_neo4j_import_pack(out_dir: Path, nodes: List[dict], edges: List[dict]) -> None:
+    """
+    Neo4j CSV import pack for consistent loading.
+    """
+    safe_mkdir(out_dir)
+    nodes_path = out_dir / "neo4j_nodes.csv"
+    edges_path = out_dir / "neo4j_edges.csv"
+    with nodes_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["id:ID", "label:LABEL", "props_json"])
+        for n in nodes:
+            w.writerow([n["node_id"], n["label"], json.dumps(n.get("props", {}), ensure_ascii=False)])
+    with edges_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow([":START_ID", ":END_ID", ":TYPE", "edge_id", "props_json"])
+        for e in edges:
+            w.writerow([e["start_id"], e["end_id"], e["type"], e["edge_id"], json.dumps(e.get("props", {}), ensure_ascii=False)])
+
+    load_cypher = """// LOAD.cypher (Cypher-based CSV load) - requires APOC for JSON parsing if you want props expanded.
+// Minimal load creates nodes with labels + props_json string (expand later if desired).
+// Example:
+// :param nodes => 'file:///neo4j_nodes.csv';
+// :param edges => 'file:///neo4j_edges.csv';
+//
+// LOAD CSV WITH HEADERS FROM $nodes AS row
+// WITH row
+// CALL {
+//   WITH row
+//   MERGE (n:Virtual {id: row.`id:ID`})
+//   SET n: `+row.`label:LABEL`+`
+//   SET n.props_json = row.props_json
+// } IN TRANSACTIONS OF 5000 ROWS;
+//
+// LOAD CSV WITH HEADERS FROM $edges AS row
+// WITH row
+// CALL {
+//   WITH row
+//   MATCH (a:Virtual {id: row.`:START_ID`})
+//   MATCH (b:Virtual {id: row.`:END_ID`})
+//   MERGE (a)-[r:VREL {edge_id: row.edge_id}]->(b)
+//   SET r.type = row.`:TYPE`
+//   SET r.props_json = row.props_json
+// } IN TRANSACTIONS OF 5000 ROWS;
+"""
+    write_text(out_dir / "LOAD.cypher", load_cypher)
+
+    constraints = """CREATE CONSTRAINT v_id IF NOT EXISTS FOR (n:Virtual) REQUIRE n.id IS UNIQUE;"""
+    indexes = """CREATE INDEX v_props IF NOT EXISTS FOR (n:Virtual) ON (n.props_json);"""
+    write_text(out_dir / "constraints.cypher", constraints)
+    write_text(out_dir / "indexes.cypher", indexes)
+
+
+def emit_dashboard_index(out_path: Path, links: Dict[str, str], title: str) -> None:
+    safe_mkdir(out_path.parent)
+    items = "\n".join([f'<li><a href="{href}">{name}</a></li>' for name, href in links.items()])
+    html = f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>{title}</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; padding: 18px; }}
+    h1 {{ margin: 0 0 10px; }}
+    ul {{ padding-left: 18px; }}
+    code {{ background: #f3f3f3; padding: 2px 4px; border-radius: 4px; }}
+    a {{ color: #1b5fd6; text-decoration: none; }}
+    a:hover {{ text-decoration: underline; }}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  <p>Quick links to core artifacts.</p>
+  <ul>
+    {items}
+  </ul>
+</body>
+</html>"""
+    write_text(out_path, html)

--- a/OUT/code/mcl_plane_suite.py
+++ b/OUT/code/mcl_plane_suite.py
@@ -1,0 +1,1582 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+MCL_PLANE_SUITE v3.0  (2026-01-26)
+
+Executive-grade, non-destructive suite:
+- Web harvest (Michigan Legislature MCL seeds + discovery)
+- Drive scan (supported file types) + <=15 doctype buckets
+- Adversarial / rights-violation / negative-statement detector (content based)
+- Chained cycles until convergence (delta-based, stable-N)
+
+Core invariants:
+- No destructive actions: never deletes, renames, or moves user originals.
+- "Bumpers not blockers": missing deps or unreadable formats do not stop a run.
+- Append-only outputs: each run writes to OUT/RUNS/<run_id>/; state snapshots are versioned.
+- OCR is never performed; unknown/scan-blocked PDFs/images are quarantined for later OCR.
+
+Outputs per run:
+- FINAL_DELIVERABLE.md
+- RUN/cycle_ledger.jsonl
+- RUN/provenance_index.json
+- RUN/blockers_and_acquisition_plan.json
+- INVENTORY/doctype_bucket_inventory.csv
+- ADVERSARIAL/findings.jsonl + findings.csv + stats.json
+- NEO4J_IMPORT/*.csv (Files, Findings, MV taxonomy, edges)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import datetime as _dt
+import hashlib
+import html
+import json
+import os
+import queue
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+
+# ----------------------------
+# Versioning
+# ----------------------------
+
+SUITE_NAME = "MCL_PLANE_SUITE"
+SUITE_VERSION = "v3.0"
+UTCNOW = lambda: _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+# ----------------------------
+# Optional deps (bumpers)
+# ----------------------------
+
+HAS_DOCX = False
+try:
+    import docx  # python-docx
+    HAS_DOCX = True
+except Exception:
+    HAS_DOCX = False
+
+HAS_STRIPRTF = False
+try:
+    from striprtf.striprtf import rtf_to_text
+    HAS_STRIPRTF = True
+except Exception:
+    HAS_STRIPRTF = False
+
+HAS_PYMUPDF = False
+try:
+    import fitz  # PyMuPDF
+    HAS_PYMUPDF = True
+except Exception:
+    HAS_PYMUPDF = False
+
+HAS_PY7ZR = False
+try:
+    import py7zr
+    HAS_PY7ZR = True
+except Exception:
+    HAS_PY7ZR = False
+
+HAS_WATCHDOG = False
+try:
+    from watchdog.observers import Observer
+    from watchdog.events import FileSystemEventHandler
+    HAS_WATCHDOG = True
+except Exception:
+    HAS_WATCHDOG = False
+
+
+# ----------------------------
+# Small utilities
+# ----------------------------
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path, bumper: "BumperLog", chunk_size: int = 1024 * 1024) -> str:
+    try:
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                h.update(chunk)
+        return h.hexdigest()
+    except Exception as e:
+        bumper.add("HASH_FAIL", str(path), {"error": repr(e)})
+        return ""
+
+
+def stable_id(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p.encode("utf-8", errors="replace"))
+        h.update(b"\x1f")
+    return h.hexdigest()[:24]
+
+
+def safe_relpath(p: Path, root: Path) -> str:
+    try:
+        return str(p.resolve().relative_to(root.resolve())).replace("\\", "/")
+    except Exception:
+        return str(p).replace("\\", "/")
+
+
+def ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(path: Path, obj: object) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n")
+
+
+def append_jsonl(path: Path, obj: dict) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8", newline="\n") as f:
+        f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
+
+def now_compact() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def mk_run_id() -> str:
+    rnd = sha256_hex(os.urandom(32))[:6]
+    return f"{now_compact()}_{rnd}"
+
+
+def is_probably_binary(path: Path) -> bool:
+    try:
+        with path.open("rb") as f:
+            chunk = f.read(2048)
+        if b"\x00" in chunk:
+            return True
+        text_chars = b"".join(bytes([i]) for i in range(32, 127)) + b"\n\r\t\b"
+        non = sum(1 for b in chunk if b not in text_chars)
+        return non / max(1, len(chunk)) > 0.30
+    except Exception:
+        return True
+
+
+def normalize_ws(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def strip_html_to_text(s: str) -> str:
+    s = re.sub(r"(?is)<(script|style)\b.*?>.*?</\1>", " ", s)
+    s = re.sub(r"(?is)<br\s*/?>", "\n", s)
+    s = re.sub(r"(?is)</p\s*>", "\n", s)
+    s = re.sub(r"(?is)<[^>]+>", " ", s)
+    s = html.unescape(s)
+    return normalize_ws(s)
+
+
+def sentence_split(text: str) -> List[str]:
+    text = text.replace("\r", "\n")
+    parts = re.split(r"(?<=[\.\!\?])\s+|\n{2,}", text)
+    out = []
+    for p in parts:
+        p = normalize_ws(p)
+        if len(p) >= 8:
+            out.append(p)
+    return out
+
+
+def token_split(text: str) -> List[str]:
+    return [t for t in re.split(r"[^A-Za-z0-9_'\-]+", text) if t]
+
+
+def safe_read_text(path: Path, bumper: "BumperLog", encoding: str = "utf-8") -> str:
+    try:
+        return path.read_text(encoding=encoding, errors="replace")
+    except Exception as e:
+        bumper.add("READ_TEXT_FAIL", str(path), {"error": repr(e)})
+        try:
+            return path.read_text(encoding="latin-1", errors="replace")
+        except Exception as e2:
+            bumper.add("READ_TEXT_FAIL_2", str(path), {"error": repr(e2)})
+            return ""
+
+
+# ----------------------------
+# Bumper log (non-blocking issues)
+# ----------------------------
+
+@dataclasses.dataclass
+class BumperItem:
+    code: str
+    target: str
+    detail: Dict
+
+
+class BumperLog:
+    def __init__(self) -> None:
+        self.items: List[BumperItem] = []
+
+    def add(self, code: str, target: str, detail: Optional[Dict] = None) -> None:
+        self.items.append(BumperItem(code=code, target=target, detail=detail or {}))
+
+    def to_json(self) -> Dict:
+        return {
+            "generated_utc": UTCNOW(),
+            "count": len(self.items),
+            "items": [dataclasses.asdict(x) for x in self.items],
+            "acquisition_plan": self._acq_plan(),
+        }
+
+    def _acq_plan(self) -> List[Dict]:
+        need = set(x.code for x in self.items)
+        plan = []
+        if any(c.startswith("DOCX_") for c in need) or ("MISSING_DEP_DOCX" in need):
+            plan.append({"install": "python-docx", "command": "pip install python-docx", "why": "DOCX text extraction"})
+        if any(c.startswith("PDF_") for c in need) or ("MISSING_DEP_PDF" in need):
+            plan.append({"install": "PyMuPDF", "command": "pip install PyMuPDF", "why": "PDF text extraction"})
+            plan.append({"install": "poppler-utils", "command": "Install pdftotext (Poppler) and ensure it is on PATH", "why": "PDF text extraction fallback"})
+        if any(c.startswith("RTF_") for c in need) or ("MISSING_DEP_RTF" in need):
+            plan.append({"install": "striprtf", "command": "pip install striprtf", "why": "RTF text extraction"})
+        if any(c.startswith("7Z_") for c in need) or ("MISSING_DEP_7Z" in need):
+            plan.append({"install": "py7zr", "command": "pip install py7zr", "why": "7z archive extraction"})
+        if any(c.startswith("WATCH_") for c in need) or ("MISSING_DEP_WATCHDOG" in need):
+            plan.append({"install": "watchdog", "command": "pip install watchdog", "why": "filesystem watcher"})
+        plan.append({
+            "note": "OCR is intentionally disabled in this suite.",
+            "next": "Run an OCR batch later on files under DEFERRED_OCR/ with your preferred OCR pipeline."
+        })
+        return plan
+
+
+# ----------------------------
+# Default schema assets
+# ----------------------------
+
+DEFAULT_DOCTYPE_REGISTRY = {
+  "version": "v1",
+  "generated_utc": UTCNOW(),
+  "buckets_max": 15,
+  "buckets": [
+    {"bucket":"B01_TEXT","ext":[".txt",".md",".log"],"extractor":"text"},
+    {"bucket":"B02_STRUCTURED","ext":[".json",".jsonl",".csv",".tsv",".xml",".yaml",".yml"],"extractor":"structured"},
+    {"bucket":"B03_HTML","ext":[".html",".htm"],"extractor":"html_text"},
+    {"bucket":"B04_DOCX","ext":[".docx"],"extractor":"docx_optional"},
+    {"bucket":"B05_RTF","ext":[".rtf"],"extractor":"rtf_optional"},
+    {"bucket":"B06_PDF_TEXT","ext":[".pdf"],"extractor":"pdf_optional"},
+    {"bucket":"B07_IMAGES","ext":[".jpg",".jpeg",".png",".webp",".tif",".tiff"],"extractor":"none"},
+    {"bucket":"B08_AUDIO","ext":[".mp3",".wav",".m4a",".aac",".flac"],"extractor":"none"},
+    {"bucket":"B09_VIDEO","ext":[".mp4",".mov",".mkv",".avi"],"extractor":"none"},
+    {"bucket":"B10_ARCHIVE","ext":[".zip",".7z",".rar"],"extractor":"archive_optional"},
+    {"bucket":"B11_CODE","ext":[".py",".ps1",".bat",".cmd",".js",".ts",".tsx",".jsx",".java",".cs",".cpp",".c",".rs",".go"],"extractor":"code_text"},
+    {"bucket":"B12_OFFICE_OTHER","ext":[".doc",".xls",".xlsx",".ppt",".pptx"],"extractor":"optional"},
+    {"bucket":"B13_EMAIL","ext":[".eml",".msg"],"extractor":"optional"},
+    {"bucket":"B14_DATABASE","ext":[".db",".sqlite",".edb"],"extractor":"none"},
+    {"bucket":"B15_OTHER","ext":["*"],"extractor":"none"}
+  ]
+}
+
+DEFAULT_EVENT_TO_MV = {
+  "version":"v1",
+  "mv_taxonomy": {
+    "MV01":"Bias/Partiality",
+    "MV02":"Weaponized_PPO",
+    "MV03":"Retaliatory_Contempt",
+    "MV04":"DueProcess_Denial",
+    "MV05":"Evidentiary_Asymmetry",
+    "MV06":"ParentingTime_Interference",
+    "MV07":"Procedural_Barrier",
+    "MV08":"Record_Tampering_Omission",
+    "MV09":"False_Report_Pattern",
+    "MV10":"Coercive_Settlement_Threats"
+  },
+  "category_to_mv": {
+    "JUDICIAL_BIAS":"MV01",
+    "CREDIBILITY_ATTACK":"MV01",
+    "EX_PARTE_ABUSE":"MV04",
+    "DUE_PROCESS":"MV04",
+    "DENIAL_OF_EVIDENCE":"MV05",
+    "DENIAL_OF_WITNESS":"MV05",
+    "PPO_WEAPONIZATION":"MV02",
+    "CONTEMPT_ABUSE":"MV03",
+    "PARENTING_TIME_WITHHELD":"MV06",
+    "BOND_BARRIER":"MV07",
+    "NOTICE_DEFECT":"MV04",
+    "HEARSAY_RELIANCE":"MV05",
+    "FALSE_REPORT":"MV09",
+    "THREAT_OR_EXTORTION":"MV10",
+    "MENTAL_HEALTH_SMEAR":"MV01",
+    "SUBSTANCE_ABUSE_SMEAR":"MV01"
+  }
+}
+
+DEFAULT_ADVERSARIAL_CONFIG = {
+    "version": "v3.0",
+    "generated_utc": UTCNOW(),
+    "notes": "Regex patterns are applied to extracted text (sentences). No OCR. Bumpers logged.",
+    "max_findings_per_file": 500,
+    "min_sentence_len": 8,
+    "max_sentence_len": 1200,
+    "stopwords": [
+        "the","and","or","to","of","in","a","an","is","are","was","were","be","been","being","it","this","that","with",
+        "for","on","at","as","by","from","but","not","no","yes","do","does","did","done","so","if","then","than","too",
+        "i","me","my","mine","you","your","yours","he","him","his","she","her","hers","they","them","their","theirs",
+        "we","us","our","ours","court","judge","hearing","order","case","motion","trial","record","transcript","evidence"
+    ],
+    "domain_anchors": [
+        "court","judge","hearing","order","motion","trial","evidence","exhibit","record","transcript",
+        "parenting time","custody","ppo","contempt","fo c","foc","due process","recusal","disqualify"
+    ],
+    "sentiment_negative": [
+        "liar","lying","crazy","insane","delusional","unhinged","unstable","dangerous","threat","abusive",
+        "harass","stalk","manipulative","vindictive","malicious","violent","meth","drug","addict","narcissist"
+    ],
+    "categories": [
+        {
+            "category": "NEGATIVE_STATEMENT",
+            "weight": 1.0,
+            "patterns": [
+                r"\b(liar|lying|dishonest|crazy|insane|delusional|unhinged|unstable|dangerous)\b",
+                r"\b(harass(?:ment)?|stalk(?:ing)?|abuse(?:d|ive)?|violent|threat(?:en|s|ening)?)\b",
+                r"\b(manipulative|vindictive|malicious|fabricat(?:e|ed|ion)|false|bogus)\b"
+            ]
+        },
+        {
+            "category": "CREDIBILITY_ATTACK",
+            "weight": 1.2,
+            "patterns": [
+                r"\b(not credible|lacks credibility|no credibility)\b",
+                r"\b(evasive|contradict(?:ion|ory|s)|inconsistent)\b",
+                r"\b(made it up|made up)\b"
+            ]
+        },
+        {
+            "category": "MENTAL_HEALTH_SMEAR",
+            "weight": 1.4,
+            "patterns": [
+                r"\b(delusional disorder|psychosis|paranoid|schizophren(?:ia|ic))\b",
+                r"\b(mental health evaluation|psych eval|psychiatric)\b",
+                r"\b(rule out delusional|rule-out delusional)\b"
+            ]
+        },
+        {
+            "category": "SUBSTANCE_ABUSE_SMEAR",
+            "weight": 1.4,
+            "patterns": [
+                r"\b(meth(?:amphetamine)?|cocaine|heroin|fentanyl|opioid)\b",
+                r"\b(drug use|substance abuse|addict(?:ion)?|under the influence)\b",
+                r"\b(drug screen|urinalysis|ua test)\b"
+            ]
+        },
+        {
+            "category": "PPO_WEAPONIZATION",
+            "weight": 1.6,
+            "patterns": [
+                r"\b(ex parte)\b.*\b(ppo|protective order)\b",
+                r"\b(weaponiz(?:e|ed|ing)|abuse)\b.*\b(ppo|protective order)\b",
+                r"\b(false)\b.*\b(ppo|protective order)\b"
+            ]
+        },
+        {
+            "category": "EX_PARTE_ABUSE",
+            "weight": 1.6,
+            "patterns": [
+                r"\b(ex parte)\b.*\b(suspend|suspension|terminate|restrict)\b.*\b(parenting time|visitation)\b",
+                r"\b(ex parte)\b.*\b(without notice|no notice)\b",
+                r"\b(irrep(?:arable)? injury)\b"
+            ]
+        },
+        {
+            "category": "DUE_PROCESS",
+            "weight": 1.7,
+            "patterns": [
+                r"\b(due process)\b",
+                r"\b(denied)\b.*\b(opportunity to be heard|a hearing|to present evidence|to testify|cross[- ]examin)\b",
+                r"\b(no notice|insufficient notice|lack of notice|without notice)\b",
+                r"\b(only.*testimony|testimony only)\b.*\b(no exhibits|no evidence)\b"
+            ]
+        },
+        {
+            "category": "DENIAL_OF_EVIDENCE",
+            "weight": 1.8,
+            "patterns": [
+                r"\b(not allowed|refused|prohibited)\b.*\b(show|present|introduce)\b.*\b(evidence|exhibits?)\b",
+                r"\b(excluded|struck)\b.*\b(evidence|exhibit)\b",
+                r"\b(ignored)\b.*\b(evidence|exhibit|record)\b"
+            ]
+        },
+        {
+            "category": "DENIAL_OF_WITNESS",
+            "weight": 1.8,
+            "patterns": [
+                r"\b(denied|refused)\b.*\b(witness|testimony|subpoena)\b",
+                r"\b(no witness list|witness list denied)\b"
+            ]
+        },
+        {
+            "category": "HEARSAY_RELIANCE",
+            "weight": 1.3,
+            "patterns": [
+                r"\b(hearsay)\b",
+                r"\b(anonymous|unnamed)\b.*\b(friend|source)\b",
+                r"\b(the child said|child said)\b"
+            ]
+        },
+        {
+            "category": "JUDICIAL_BIAS",
+            "weight": 2.0,
+            "patterns": [
+                r"\b(judge)\b.*\b(called me|called him|called her)\b.*\b(liar|crazy|delusional)\b",
+                r"\b(asymmetric)\b.*\b(ruling|treatment)\b",
+                r"\b(bias|partiality)\b"
+            ]
+        },
+        {
+            "category": "CONTEMPT_ABUSE",
+            "weight": 1.9,
+            "patterns": [
+                r"\b(contempt)\b.*\b(jail|incarcerat|14 days|sentenced)\b",
+                r"\b(show cause)\b.*\b(2 hours|short notice|no notice)\b",
+                r"\b(criminal contempt)\b"
+            ]
+        },
+        {
+            "category": "PARENTING_TIME_WITHHELD",
+            "weight": 1.9,
+            "patterns": [
+                r"\b(denied|withheld|refused)\b.*\b(parenting time|visitation)\b",
+                r"\b(no contact)\b.*\b(child|son|daughter)\b",
+                r"\b(alienat(?:e|ion)|interfer(?:e|ence))\b.*\b(parenting time|relationship)\b"
+            ]
+        },
+        {
+            "category": "BOND_BARRIER",
+            "weight": 1.6,
+            "patterns": [
+                r"\b(bond requirement|motion bond)\b",
+                r"\b(must post)\b.*\b(bond)\b.*\b(future motions?)\b"
+            ]
+        },
+        {
+            "category": "FALSE_REPORT",
+            "weight": 1.4,
+            "patterns": [
+                r"\b(false report|false police report)\b",
+                r"\b(welfare check)\b.*\b(false)\b",
+                r"\b(filed)\b.*\b(police reports?)\b.*\b(false|bogus)\b"
+            ]
+        },
+        {
+            "category": "THREAT_OR_EXTORTION",
+            "weight": 1.5,
+            "patterns": [
+                r"\b(threaten(?:ed|ing)?)\b.*\b(evict|jail|take the child|terminate)\b",
+                r"\b(accept)\b.*\b(rent increase)\b.*\b(or)\b.*\b(evict|sell|lose)\b"
+            ]
+        }
+    ],
+    "mv_mapping": DEFAULT_EVENT_TO_MV
+}
+
+
+# ----------------------------
+# File inventory + bucketization
+# ----------------------------
+
+def load_doctype_registry(path: Optional[Path], bumper: BumperLog) -> Dict:
+    if path and path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            bumper.add("LOAD_DOCTYPE_REG_FAIL", str(path), {"error": repr(e)})
+    return DEFAULT_DOCTYPE_REGISTRY
+
+
+def bucket_for_ext(ext: str, registry: Dict) -> str:
+    ext = (ext or "").lower()
+    for b in registry.get("buckets", []):
+        exts = b.get("ext", [])
+        if "*" in exts:
+            continue
+        if ext in [x.lower() for x in exts]:
+            return b.get("bucket", "B15_OTHER")
+    return "B15_OTHER"
+
+
+def iter_files(roots: List[Path], bumper: BumperLog, excludes: List[str], max_files: int) -> Iterator[Path]:
+    seen = 0
+    ex_re = [re.compile(x, re.I) for x in excludes if x]
+    for root in roots:
+        root = root.expanduser()
+        if not root.exists():
+            bumper.add("SCAN_ROOT_MISSING", str(root), {})
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            d = dirpath.replace("\\", "/")
+            if any(r.search(d) for r in ex_re):
+                dirnames[:] = []
+                continue
+            dirnames[:] = [dn for dn in dirnames if not any(r.search((d + "/" + dn)) for r in ex_re)]
+            for fn in filenames:
+                p = Path(dirpath) / fn
+                fp = str(p).replace("\\", "/")
+                if any(r.search(fp) for r in ex_re):
+                    continue
+                yield p
+                seen += 1
+                if max_files > 0 and seen >= max_files:
+                    bumper.add("MAX_FILES_REACHED", str(max_files), {"note": "Increase --max-files to scan more."})
+                    return
+
+
+def write_bucket_inventory(files: List[Path], registry: Dict, roots: List[Path], out_csv: Path) -> None:
+    ensure_dir(out_csv.parent)
+    with out_csv.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["bucket", "ext", "size_bytes", "mtime_utc", "path"])
+        for p in files:
+            ext = p.suffix.lower()
+            bucket = bucket_for_ext(ext, registry)
+            try:
+                st = p.stat()
+                mtime = _dt.datetime.fromtimestamp(st.st_mtime, tz=_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                size = st.st_size
+            except Exception:
+                mtime, size = "", ""
+            w.writerow([bucket, ext, size, mtime, str(p)])
+
+
+# ----------------------------
+# Text extraction (no OCR)
+# ----------------------------
+
+def extract_text_from_docx(path: Path, bumper: BumperLog) -> str:
+    if not HAS_DOCX:
+        bumper.add("MISSING_DEP_DOCX", str(path), {"install": "python-docx"})
+        return ""
+    try:
+        doc = docx.Document(str(path))
+        paras = [p.text for p in doc.paragraphs if p.text and p.text.strip()]
+        return "\n".join(paras)
+    except Exception as e:
+        bumper.add("DOCX_EXTRACT_FAIL", str(path), {"error": repr(e)})
+        return ""
+
+
+def extract_text_from_rtf(path: Path, bumper: BumperLog) -> str:
+    if not HAS_STRIPRTF:
+        bumper.add("MISSING_DEP_RTF", str(path), {"install": "striprtf"})
+        return ""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        return rtf_to_text(raw)
+    except Exception as e:
+        bumper.add("RTF_EXTRACT_FAIL", str(path), {"error": repr(e)})
+        return ""
+
+
+def extract_text_from_pdf(path: Path, bumper: BumperLog, page_limit: int = 200) -> Tuple[str, List[Dict]]:
+    page_spans: List[Dict] = []
+    if HAS_PYMUPDF:
+        try:
+            doc = fitz.open(str(path))
+            chunks = []
+            pos = 0
+            for i, page in enumerate(doc):
+                if i >= page_limit:
+                    bumper.add("PDF_PAGE_LIMIT", str(path), {"limit": page_limit})
+                    break
+                t = page.get_text("text") or ""
+                start = pos
+                chunks.append(t)
+                pos += len(t)
+                page_spans.append({"page": i + 1, "start": start, "end": pos})
+            doc.close()
+            return "\n".join(chunks), page_spans
+        except Exception as e:
+            bumper.add("PDF_PYMUPDF_FAIL", str(path), {"error": repr(e)})
+    try:
+        proc = subprocess.run(["pdftotext", str(path), "-"],
+                              capture_output=True, text=True, timeout=120)
+        if proc.returncode == 0:
+            txt = proc.stdout or ""
+            return txt, page_spans
+        bumper.add("PDF_PDFTOTEXT_FAIL", str(path), {"stderr": (proc.stderr or "")[:500]})
+    except FileNotFoundError:
+        bumper.add("MISSING_DEP_PDF", str(path), {"install": "PyMuPDF or pdftotext"})
+    except Exception as e:
+        bumper.add("PDF_PDFTOTEXT_ERR", str(path), {"error": repr(e)})
+    return "", page_spans
+
+
+def extract_text_from_structured(path: Path, bumper: BumperLog, max_chars: int = 4_000_000) -> str:
+    ext = path.suffix.lower()
+    try:
+        if ext in [".json", ".jsonl"]:
+            txt = safe_read_text(path, bumper)
+            if ext == ".jsonl":
+                vals = []
+                for line in txt.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                        vals.append(json.dumps(obj, ensure_ascii=False))
+                    except Exception:
+                        vals.append(line)
+                out = "\n".join(vals)
+            else:
+                try:
+                    obj = json.loads(txt)
+                    out = json.dumps(obj, ensure_ascii=False)
+                except Exception:
+                    out = txt
+            return out[:max_chars]
+        if ext in [".csv", ".tsv"]:
+            delim = "\t" if ext == ".tsv" else ","
+            rows = []
+            with path.open("r", encoding="utf-8", errors="replace", newline="") as f:
+                reader = csv.reader(f, delimiter=delim)
+                for i, row in enumerate(reader):
+                    rows.append(" | ".join(row))
+                    if i >= 200_000:
+                        bumper.add("CSV_ROW_LIMIT", str(path), {"limit": 200000})
+                        break
+            return "\n".join(rows)[:max_chars]
+        return safe_read_text(path, bumper)[:max_chars]
+    except Exception as e:
+        bumper.add("STRUCT_EXTRACT_FAIL", str(path), {"error": repr(e)})
+        return ""
+
+
+def extract_text_from_code(path: Path, bumper: BumperLog, max_chars: int = 2_000_000) -> str:
+    if is_probably_binary(path):
+        bumper.add("CODE_BINARY_SKIP", str(path), {})
+        return ""
+    return safe_read_text(path, bumper)[:max_chars]
+
+
+def extract_text_any(path: Path, bumper: BumperLog) -> Tuple[str, Dict]:
+    ext = path.suffix.lower()
+    meta = {"extractor": None, "deferred": False, "page_spans": []}
+    if ext in [".txt", ".md", ".log"]:
+        meta["extractor"] = "text"
+        return safe_read_text(path, bumper), meta
+    if ext in [".html", ".htm"]:
+        meta["extractor"] = "html"
+        return strip_html_to_text(safe_read_text(path, bumper)), meta
+    if ext in [".json", ".jsonl", ".csv", ".tsv", ".xml", ".yaml", ".yml"]:
+        meta["extractor"] = "structured"
+        return extract_text_from_structured(path, bumper), meta
+    if ext in [".py", ".ps1", ".bat", ".cmd", ".js", ".ts", ".tsx", ".jsx", ".java", ".cs", ".cpp", ".c", ".rs", ".go"]:
+        meta["extractor"] = "code"
+        return extract_text_from_code(path, bumper), meta
+    if ext == ".docx":
+        meta["extractor"] = "docx"
+        text = extract_text_from_docx(path, bumper)
+        if not text:
+            meta["deferred"] = True
+        return text, meta
+    if ext == ".rtf":
+        meta["extractor"] = "rtf"
+        text = extract_text_from_rtf(path, bumper)
+        if not text:
+            meta["deferred"] = True
+        return text, meta
+    if ext == ".pdf":
+        meta["extractor"] = "pdf"
+        text, spans = extract_text_from_pdf(path, bumper)
+        meta["page_spans"] = spans
+        if not text:
+            meta["deferred"] = True
+        return text, meta
+    meta["extractor"] = "none"
+    return "", meta
+
+
+# ----------------------------
+# Adversarial scan
+# ----------------------------
+
+@dataclasses.dataclass
+class Finding:
+    finding_id: str
+    file_path: str
+    file_rel: str
+    location: str
+    offset_start: int
+    offset_end: int
+    category: str
+    mv_code: str
+    weight: float
+    pattern: str
+    snippet: str
+    snippet_hash: str
+    created_utc: str
+
+
+def load_adversarial_config(path: Optional[Path], bumper: BumperLog) -> Dict:
+    if path and path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            bumper.add("LOAD_ADVERSARIAL_CONFIG_FAIL", str(path), {"error": repr(e)})
+    return DEFAULT_ADVERSARIAL_CONFIG
+
+
+def compile_patterns(cfg: Dict) -> List[Tuple[str, float, re.Pattern]]:
+    out = []
+    for c in cfg.get("categories", []):
+        cat = c.get("category")
+        w = float(c.get("weight", 1.0))
+        for pat in c.get("patterns", []):
+            try:
+                out.append((cat, w, re.compile(pat, re.I)))
+            except re.error:
+                continue
+    return out
+
+
+def mv_for_category(category: str, cfg: Dict) -> str:
+    mapping = ((cfg.get("mv_mapping") or {}).get("category_to_mv") or {})
+    return mapping.get(category, "")
+
+
+def map_offset_to_page(offset: int, page_spans: List[Dict]) -> Optional[int]:
+    for sp in page_spans:
+        if sp["start"] <= offset < sp["end"]:
+            return int(sp["page"])
+    return None
+
+
+def adversarial_scan_files(files: List[Path], scan_roots: List[Path], out_dir: Path, cfg: Dict, bumper: BumperLog) -> Dict:
+    ensure_dir(out_dir)
+    findings_jsonl = out_dir / "findings.jsonl"
+    findings_csv = out_dir / "findings.csv"
+    stats_json = out_dir / "stats.json"
+    ensure_dir(out_dir.parent / "DEFERRED_OCR")
+
+    compiled = compile_patterns(cfg)
+    max_per_file = int(cfg.get("max_findings_per_file", 500))
+    min_len = int(cfg.get("min_sentence_len", 8))
+    max_len = int(cfg.get("max_sentence_len", 1200))
+
+    findings: List[Finding] = []
+    deferred: List[Dict] = []
+    file_count = 0
+    scanned_files = 0
+
+    with findings_csv.open("w", encoding="utf-8", newline="") as fcsv:
+        w = csv.writer(fcsv)
+        w.writerow(["finding_id", "mv_code", "category", "weight", "pattern", "location", "offset_start", "offset_end", "path", "snippet", "snippet_hash"])
+        for fp in files:
+            file_count += 1
+            txt, meta = extract_text_any(fp, bumper)
+
+            file_rel = ""
+            for r in scan_roots:
+                if fp.is_absolute() and str(fp).lower().startswith(str(r).lower()):
+                    file_rel = safe_relpath(fp, r)
+                    break
+            if not file_rel:
+                file_rel = fp.name
+
+            if meta.get("deferred"):
+                deferred.append({"path": str(fp), "reason": "text_extraction_failed_or_missing_dep", "extractor": meta.get("extractor")})
+                continue
+
+            if not txt:
+                continue
+
+            scanned_files += 1
+            sentences = sentence_split(txt)
+            cum = 0
+            per_file = 0
+            for s in sentences:
+                if len(s) < min_len:
+                    cum += len(s) + 1
+                    continue
+                if len(s) > max_len:
+                    s = s[:max_len]
+
+                found_in_sentence = 0
+                for cat, weight, rx in compiled:
+                    m = rx.search(s)
+                    if not m:
+                        continue
+                    mv = mv_for_category(cat, cfg)
+                    loc = ""
+                    if meta.get("extractor") == "pdf" and meta.get("page_spans"):
+                        page = map_offset_to_page(cum, meta.get("page_spans", []))
+                        if page:
+                            loc = f"page:{page}"
+                    if not loc:
+                        loc = "sentence"
+
+                    snip = normalize_ws(s)
+                    fid = stable_id(str(fp), cat, rx.pattern, snip[:200])
+                    finding = Finding(
+                        finding_id=fid,
+                        file_path=str(fp),
+                        file_rel=file_rel,
+                        location=loc,
+                        offset_start=cum,
+                        offset_end=cum + len(s),
+                        category=cat,
+                        mv_code=mv,
+                        weight=float(weight),
+                        pattern=rx.pattern,
+                        snippet=snip[:1000],
+                        snippet_hash=sha256_hex(snip.encode("utf-8", errors="replace")),
+                        created_utc=UTCNOW(),
+                    )
+                    findings.append(finding)
+                    append_jsonl(findings_jsonl, dataclasses.asdict(finding))
+                    w.writerow([fid, mv, cat, weight, rx.pattern, loc, cum, cum + len(s), str(fp), snip[:500], sha256_hex(snip.encode("utf-8", errors="replace"))])
+
+                    found_in_sentence += 1
+                    per_file += 1
+                    if found_in_sentence >= 5:
+                        break
+                    if per_file >= max_per_file:
+                        bumper.add("MAX_FINDINGS_PER_FILE", str(fp), {"limit": max_per_file})
+                        break
+                if per_file >= max_per_file:
+                    break
+                cum += len(s) + 1
+
+    if deferred:
+        write_json(out_dir / "deferred_extraction.json", {"count": len(deferred), "items": deferred})
+
+    stats = {
+        "generated_utc": UTCNOW(),
+        "files_seen": file_count,
+        "files_scanned_text": scanned_files,
+        "findings_count": len(findings),
+        "unique_files_with_findings": len(set(f.file_path for f in findings)),
+        "categories": {},
+        "mv_codes": {},
+    }
+    for fnd in findings:
+        stats["categories"][fnd.category] = stats["categories"].get(fnd.category, 0) + 1
+        mv = fnd.mv_code or ""
+        if mv:
+            stats["mv_codes"][mv] = stats["mv_codes"].get(mv, 0) + 1
+
+    write_json(stats_json, stats)
+    return stats
+
+
+def derive_auto_terms(findings: List[Finding], cfg: Dict, top_k: int = 50) -> List[str]:
+    stop = set((cfg.get("stopwords") or []))
+    counts: Dict[str, int] = {}
+    for fnd in findings:
+        toks = [t.lower() for t in token_split(fnd.snippet)]
+        for t in toks:
+            if len(t) < 4:
+                continue
+            if t in stop:
+                continue
+            if t.isdigit():
+                continue
+            counts[t] = counts.get(t, 0) + 1
+    items = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [k for k, v in items if v >= 2][:top_k]
+
+
+def augment_config_with_auto_terms(cfg: Dict, auto_terms: List[str]) -> Dict:
+    cfg2 = json.loads(json.dumps(cfg))
+    if not auto_terms:
+        return cfg2
+    pats = [rf"\b{re.escape(t)}\b" for t in auto_terms]
+    cfg2.setdefault("categories", []).append({
+        "category": "AUTO_DISCOVERED_TERM",
+        "weight": 0.6,
+        "patterns": pats
+    })
+    return cfg2
+
+
+def adversarial_converge(files: List[Path], scan_roots: List[Path], run_root: Path, base_cfg: Dict,
+                         bumper: BumperLog, cycles: int, eps: int, stable_n: int) -> Dict:
+    adv_root = run_root / "ADVERSARIAL"
+    ensure_dir(adv_root)
+    state_dir = run_root / "STATE"
+    ensure_dir(state_dir)
+
+    cycle_ledger = run_root / "RUN" / "cycle_ledger.jsonl"
+
+    last_total = 0
+    stable = 0
+    cfg = base_cfg
+    all_findings: Dict[str, Finding] = {}
+
+    for c in range(1, cycles + 1):
+        cycle_dir = adv_root / f"CYCLE_{c:02d}"
+        ensure_dir(cycle_dir)
+
+        stats = adversarial_scan_files(files, scan_roots, cycle_dir, cfg, bumper)
+
+        findings_jsonl = cycle_dir / "findings.jsonl"
+        new_count = 0
+        cycle_findings: List[Finding] = []
+        if findings_jsonl.exists():
+            for line in findings_jsonl.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                    fnd = Finding(**d)
+                    cycle_findings.append(fnd)
+                    if fnd.finding_id not in all_findings:
+                        all_findings[fnd.finding_id] = fnd
+                        new_count += 1
+                except Exception:
+                    continue
+
+        total = len(all_findings)
+        delta = total - last_total
+        last_total = total
+
+        append_jsonl(cycle_ledger, {
+            "ts_utc": UTCNOW(),
+            "phase": "adversarial_cycle",
+            "cycle": c,
+            "cycle_new_findings": new_count,
+            "total_findings": total,
+            "delta": delta,
+            "eps": eps,
+            "stable_n": stable_n,
+            "stats": stats
+        })
+
+        auto_terms = derive_auto_terms(cycle_findings, cfg, top_k=60)
+        write_json(state_dir / f"auto_terms_cycle_{c:02d}.json", {"cycle": c, "terms": auto_terms})
+
+        cfg_next = augment_config_with_auto_terms(base_cfg, auto_terms)
+
+        if delta <= eps:
+            stable += 1
+        else:
+            stable = 0
+
+        if stable >= stable_n:
+            append_jsonl(cycle_ledger, {
+                "ts_utc": UTCNOW(),
+                "phase": "adversarial_converged",
+                "cycle": c,
+                "stable": stable,
+                "total_findings": total
+            })
+            cfg = cfg_next
+            break
+
+        cfg = cfg_next
+
+    consolidated_dir = adv_root / "CONSOLIDATED"
+    ensure_dir(consolidated_dir)
+    con_jsonl = consolidated_dir / "findings.jsonl"
+    con_csv = consolidated_dir / "findings.csv"
+    with con_jsonl.open("w", encoding="utf-8", newline="\n") as f:
+        for fid in sorted(all_findings.keys()):
+            f.write(json.dumps(dataclasses.asdict(all_findings[fid]), ensure_ascii=False) + "\n")
+    with con_csv.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["finding_id", "mv_code", "category", "weight", "pattern", "location", "offset_start", "offset_end", "path", "snippet"])
+        for fid in sorted(all_findings.keys()):
+            fnd = all_findings[fid]
+            w.writerow([fnd.finding_id, fnd.mv_code, fnd.category, fnd.weight, fnd.pattern, fnd.location, fnd.offset_start, fnd.offset_end, fnd.file_path, fnd.snippet])
+
+    summ = {"generated_utc": UTCNOW(), "total_findings": len(all_findings),
+            "categories": {}, "mv_codes": {}}
+    for fnd in all_findings.values():
+        summ["categories"][fnd.category] = summ["categories"].get(fnd.category, 0) + 1
+        if fnd.mv_code:
+            summ["mv_codes"][fnd.mv_code] = summ["mv_codes"].get(fnd.mv_code, 0) + 1
+    write_json(consolidated_dir / "summary.json", summ)
+    return summ
+
+
+# ----------------------------
+# Neo4j export (CSV)
+# ----------------------------
+
+def neo4j_export(run_root: Path, files: List[Path], scan_roots: List[Path], adv_summary: Dict, cfg: Dict, evidence_index: Dict[str, Dict]) -> None:
+    neo = run_root / "NEO4J_IMPORT"
+    ensure_dir(neo)
+    files_csv = neo / "nodes_files.csv"
+    findings_csv = neo / "nodes_findings.csv"
+    mv_csv = neo / "nodes_mv.csv"
+    rel_file_has_finding = neo / "rels_file_has_finding.csv"
+    rel_finding_maps_mv = neo / "rels_finding_maps_mv.csv"
+
+    with files_csv.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["file_id:ID", "path", "relpath", "ext", "bucket", "size_bytes:long", "mtime_utc", "sha256"])
+        reg = DEFAULT_DOCTYPE_REGISTRY
+        for p in files:
+            ext = p.suffix.lower()
+            bucket = bucket_for_ext(ext, reg)
+            try:
+                st = p.stat()
+                size = st.st_size
+                mtime = _dt.datetime.fromtimestamp(st.st_mtime, tz=_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            except Exception:
+                size, mtime = "", ""
+            rel = ""
+            for r in scan_roots:
+                if str(p).lower().startswith(str(r).lower()):
+                    rel = safe_relpath(p, r)
+                    break
+            fid = stable_id(str(p))
+            sha = evidence_index.get(str(p), {}).get("sha256", "")
+            w.writerow([fid, str(p), rel, ext, bucket, size, mtime, sha])
+
+    mv_tax = (cfg.get("mv_mapping") or {}).get("mv_taxonomy") or {}
+    with mv_csv.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["mv_code:ID", "label"])
+        for code, label in sorted(mv_tax.items()):
+            w.writerow([code, label])
+
+    consolidated = run_root / "ADVERSARIAL" / "CONSOLIDATED" / "findings.jsonl"
+    if not consolidated.exists():
+        return
+
+    with findings_csv.open("w", encoding="utf-8", newline="") as f_nodes, \
+         rel_file_has_finding.open("w", encoding="utf-8", newline="") as f_rel1, \
+         rel_finding_maps_mv.open("w", encoding="utf-8", newline="") as f_rel2:
+        wn = csv.writer(f_nodes)
+        wr1 = csv.writer(f_rel1)
+        wr2 = csv.writer(f_rel2)
+        wn.writerow(["finding_id:ID", "category", "mv_code", "weight:float", "pattern", "location", "offset_start:long", "offset_end:long", "snippet", "snippet_hash", "created_utc", "file_path"])
+        wr1.writerow([":START_ID", ":END_ID", ":TYPE"])
+        wr2.writerow([":START_ID", ":END_ID", ":TYPE"])
+        for line in consolidated.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except Exception:
+                continue
+            wn.writerow([d.get("finding_id"), d.get("category"), d.get("mv_code"), d.get("weight"),
+                         d.get("pattern"), d.get("location"), d.get("offset_start"), d.get("offset_end"),
+                         d.get("snippet"), d.get("snippet_hash"), d.get("created_utc"), d.get("file_path")])
+            file_id = stable_id(d.get("file_path", ""))
+            wr1.writerow([file_id, d.get("finding_id"), "HAS_FINDING"])
+            if d.get("mv_code"):
+                wr2.writerow([d.get("finding_id"), d.get("mv_code"), "MAPS_TO_MV"])
+
+
+# ----------------------------
+# Web harvest (minimal)
+# ----------------------------
+
+def load_seeds(seeds_dir: Path, bumper: BumperLog) -> List[str]:
+    urls: Set[str] = set()
+    for fn in ["seed_urls.txt", "seed_urls_user.txt"]:
+        p = seeds_dir / fn
+        if p.exists():
+            for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+                u = line.strip()
+                if not u or u.startswith("#"):
+                    continue
+                urls.add(u)
+    if not urls:
+        urls.update([
+            "https://www.legislature.mi.gov/",
+            "https://www.legislature.mi.gov/Laws/MCL",
+            "https://www.legislature.mi.gov/Laws/ChapterIndex",
+            "https://www.legislature.mi.gov/Bills",
+            "https://www.legislature.mi.gov/Committees",
+        ])
+    return sorted(urls)
+
+
+def is_http_url(u: str) -> bool:
+    try:
+        p = urllib.parse.urlparse(u)
+        return p.scheme in ("http", "https")
+    except Exception:
+        return False
+
+
+def normalize_url(u: str) -> str:
+    try:
+        u = u.strip()
+        p = urllib.parse.urlparse(u)
+        if not p.scheme:
+            return ""
+        p = p._replace(fragment="")
+        return p.geturl()
+    except Exception:
+        return ""
+
+
+def fetch_url(url: str, out_dir: Path, bumper: BumperLog, timeout: int = 30, max_bytes: int = 20_000_000) -> Optional[Path]:
+    ensure_dir(out_dir)
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (LitigationOS MCL Plane Suite)"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            ct = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            data = resp.read(max_bytes + 1)
+            if len(data) > max_bytes:
+                bumper.add("FETCH_MAX_BYTES", url, {"max_bytes": max_bytes})
+                return None
+            ext = ".html"
+            if "pdf" in ct or url.lower().endswith(".pdf"):
+                ext = ".pdf"
+            elif "json" in ct or url.lower().endswith(".json"):
+                ext = ".json"
+            elif "xml" in ct or url.lower().endswith(".xml"):
+                ext = ".xml"
+            fn = stable_id(url) + ext
+            p = out_dir / fn
+            p.write_bytes(data)
+            return p
+    except Exception as e:
+        bumper.add("FETCH_FAIL", url, {"error": repr(e)})
+        return None
+
+
+def discover_links_from_html(text: str, base_url: str) -> List[str]:
+    links = set()
+    for m in re.finditer(r'href=["\']([^"\']+)["\']', text, flags=re.I):
+        href = m.group(1).strip()
+        if not href:
+            continue
+        if href.startswith("mailto:") or href.startswith("javascript:"):
+            continue
+        absu = urllib.parse.urljoin(base_url, href)
+        absu = normalize_url(absu)
+        if absu and is_http_url(absu):
+            links.add(absu)
+    return sorted(links)
+
+
+def web_harvest_cycle(seed_urls: List[str], run_root: Path, bumper: BumperLog,
+                      max_fetch: int = 40, max_discover: int = 200) -> Dict:
+    web_dir = run_root / "WEB"
+    ensure_dir(web_dir)
+    fetched_dir = web_dir / "FETCHED"
+    ensure_dir(fetched_dir)
+
+    q: queue.Queue[str] = queue.Queue()
+    for u in seed_urls:
+        u = normalize_url(u)
+        if u:
+            q.put(u)
+
+    seen: Set[str] = set()
+    fetched: List[Dict] = []
+    discovered: Set[str] = set()
+
+    while not q.empty() and len(fetched) < max_fetch:
+        u = q.get()
+        if u in seen:
+            continue
+        seen.add(u)
+        path = fetch_url(u, fetched_dir, bumper)
+        if path is None:
+            continue
+        fetched.append({"url": u, "path": str(path)})
+        if path.suffix.lower() in [".html", ".htm"]:
+            txt = safe_read_text(path, bumper)
+            for lnk in discover_links_from_html(txt, u):
+                if len(discovered) >= max_discover:
+                    break
+                if "legislature.mi.gov" in lnk.lower():
+                    discovered.add(lnk)
+
+    write_json(web_dir / "fetched.json", {"generated_utc": UTCNOW(), "count": len(fetched), "items": fetched})
+    write_json(web_dir / "discovered.json", {"generated_utc": UTCNOW(), "count": len(discovered), "items": sorted(discovered)})
+    return {"fetched": len(fetched), "discovered": len(discovered)}
+
+
+# ----------------------------
+# Convergence orchestrator
+# ----------------------------
+
+def converge(run_root: Path, in_root: Path, out_root: Path, scan_roots: List[Path],
+             doctype_registry: Dict, adv_cfg_path: Optional[Path], bumper: BumperLog,
+             cycles: int, eps: int, stable_n: int, adversarial: bool,
+             adv_cycles: int, adv_eps: int, adv_stable_n: int,
+             web_enabled: bool, max_files: int, excludes: List[str], max_fetch: int,
+             hash_files: bool) -> Dict:
+    run_dir = run_root
+    ensure_dir(run_dir)
+
+    ensure_dir(run_dir / "RUN")
+    ensure_dir(run_dir / "INVENTORY")
+
+    ledger = run_dir / "RUN" / "cycle_ledger.jsonl"
+
+    seeds_dir = out_root / "seeds"
+    ensure_dir(seeds_dir)
+    user_seed = in_root / "seed_urls_user.txt"
+    if user_seed.exists():
+        shutil.copy2(user_seed, seeds_dir / "seed_urls_user.txt")
+
+    seed_urls = load_seeds(seeds_dir, bumper)
+
+    files = list(iter_files(scan_roots, bumper, excludes=excludes, max_files=max_files))
+    inv_csv = run_dir / "INVENTORY" / "doctype_bucket_inventory.csv"
+    write_bucket_inventory(files, doctype_registry, scan_roots, inv_csv)
+    evidence_index = build_evidence_index(files, run_dir / "RUN" / "evidence_index.jsonl", bumper, hash_files)
+
+    last_metric = 0
+    stable = 0
+    best_summary: Dict = {}
+
+    for c in range(1, cycles + 1):
+        wh = web_harvest_cycle(seed_urls, run_dir, bumper, max_fetch=max_fetch) if web_enabled else {"fetched": 0, "discovered": 0}
+
+        adv_summary: Dict = {}
+        if adversarial:
+            adv_cfg = load_adversarial_config(adv_cfg_path, bumper)
+            fetched_paths = []
+            fetched_json = run_dir / "WEB" / "fetched.json"
+            if fetched_json.exists():
+                try:
+                    data = json.loads(fetched_json.read_text(encoding="utf-8"))
+                    for it in data.get("items", []):
+                        p = Path(it.get("path", ""))
+                        if p.exists():
+                            fetched_paths.append(p)
+                except Exception:
+                    pass
+            scan_files = files + fetched_paths
+            adv_summary = adversarial_converge(
+                files=scan_files,
+                scan_roots=scan_roots,
+                run_root=run_dir,
+                base_cfg=adv_cfg,
+                bumper=bumper,
+                cycles=max(1, int(adv_cycles)),
+                eps=int(adv_eps),
+                stable_n=max(1, int(adv_stable_n))
+            )
+            best_summary = adv_summary
+
+        metric = int((best_summary.get("total_findings") or 0)) + int(wh.get("fetched") or 0)
+        delta = metric - last_metric
+        last_metric = metric
+
+        append_jsonl(ledger, {
+            "ts_utc": UTCNOW(),
+            "phase": "outer_cycle",
+            "cycle": c,
+            "metric": metric,
+            "delta": delta,
+            "eps": eps,
+            "stable_n": stable_n,
+            "web": wh,
+            "adversarial": adv_summary
+        })
+
+        if delta <= eps:
+            stable += 1
+        else:
+            stable = 0
+
+        if stable >= stable_n:
+            append_jsonl(ledger, {
+                "ts_utc": UTCNOW(),
+                "phase": "outer_converged",
+                "cycle": c,
+                "stable": stable,
+                "metric": metric
+            })
+            break
+
+    if adversarial:
+        adv_cfg = load_adversarial_config(adv_cfg_path, bumper)
+        neo4j_export(run_dir, files, scan_roots, best_summary, adv_cfg, evidence_index)
+
+    final_md = run_dir / "FINAL_DELIVERABLE.md"
+    final = {
+        "suite": {"name": SUITE_NAME, "version": SUITE_VERSION},
+        "run_id": run_dir.name,
+        "generated_utc": UTCNOW(),
+        "scan_roots": [str(p) for p in scan_roots],
+        "files_seen": len(files),
+        "adversarial_enabled": bool(adversarial),
+        "adversarial_summary": best_summary,
+        "web_harvest_enabled": bool(web_enabled),
+    }
+    final_md.write_text("# FINAL_DELIVERABLE\n\n```json\n" + json.dumps(final, indent=2) + "\n```\n", encoding="utf-8", newline="\n")
+
+    prov = {
+        "generated_utc": UTCNOW(),
+        "suite_version": SUITE_VERSION,
+        "python": sys.version,
+        "platform": sys.platform,
+        "optional_deps": {
+            "python-docx": HAS_DOCX,
+            "striprtf": HAS_STRIPRTF,
+            "PyMuPDF": HAS_PYMUPDF,
+            "py7zr": HAS_PY7ZR,
+            "watchdog": HAS_WATCHDOG,
+        }
+    }
+    write_json(run_dir / "RUN" / "provenance_index.json", prov)
+    write_json(run_dir / "RUN" / "blockers_and_acquisition_plan.json", bumper.to_json())
+    write_run_manifest(run_dir, in_root, out_root, scan_roots, files, best_summary, web_enabled, adversarial, hash_files, excludes, max_files)
+
+    return final
+
+
+def build_evidence_index(files: List[Path], out_path: Path, bumper: BumperLog, hash_files: bool) -> Dict[str, Dict]:
+    ensure_dir(out_path.parent)
+    index: Dict[str, Dict] = {}
+    with out_path.open("w", encoding="utf-8", newline="\n") as f:
+        for p in files:
+            try:
+                st = p.stat()
+                mtime = _dt.datetime.fromtimestamp(st.st_mtime, tz=_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                size = st.st_size
+            except Exception:
+                mtime, size = "", ""
+            sha = sha256_file(p, bumper) if hash_files else ""
+            row = {
+                "path": str(p),
+                "size_bytes": size,
+                "mtime_utc": mtime,
+                "sha256": sha,
+            }
+            index[str(p)] = row
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return index
+
+
+def write_run_manifest(run_root: Path, in_root: Path, out_root: Path, scan_roots: List[Path], files: List[Path],
+                       adv_summary: Dict, web_enabled: bool, adversarial: bool, hash_files: bool,
+                       excludes: List[str], max_files: int) -> None:
+    manifest = {
+        "generated_utc": UTCNOW(),
+        "run_id": run_root.name,
+        "inputs": {
+            "in_root": str(in_root),
+            "scan_roots": [str(p) for p in scan_roots],
+            "excludes": excludes,
+            "max_files": max_files,
+        },
+        "features": {
+            "adversarial": adversarial,
+            "web_harvest": web_enabled,
+            "hash_files": hash_files,
+        },
+        "counts": {
+            "files_seen": len(files),
+            "findings_total": adv_summary.get("total_findings", 0),
+        },
+        "outputs": {
+            "inventory_csv": str(run_root / "INVENTORY" / "doctype_bucket_inventory.csv"),
+            "evidence_index": str(run_root / "RUN" / "evidence_index.jsonl"),
+            "adversarial_summary": str(run_root / "ADVERSARIAL" / "CONSOLIDATED" / "summary.json") if adversarial else "",
+        },
+    }
+    write_json(run_root / "RUN" / "run_manifest.json", manifest)
+
+
+# ----------------------------
+# Watch mode
+# ----------------------------
+
+if HAS_WATCHDOG:
+    class _WatchHandler(FileSystemEventHandler):  # type: ignore
+        def __init__(self, trigger_fn):
+            self.trigger_fn = trigger_fn
+
+        def on_any_event(self, event):
+            self.trigger_fn(event)
+else:
+    class _WatchHandler(object):
+        def __init__(self, trigger_fn):
+            self.trigger_fn = trigger_fn
+
+
+def watch_and_incremental(args, scan_roots: List[Path], doctype_registry: Dict, bumper: BumperLog) -> None:
+    if not HAS_WATCHDOG:
+        bumper.add("MISSING_DEP_WATCHDOG", "watch_mode", {"install": "watchdog"})
+        return
+    run_id = mk_run_id()
+    run_root = Path(args.out_path) / "RUNS" / run_id
+    ensure_dir(run_root)
+    debounce_s = 2.0
+    last = {"t": 0.0}
+
+    def trigger(event):
+        t = time.time()
+        if (t - last["t"]) < debounce_s:
+            return
+        last["t"] = t
+        try:
+            converge(
+                run_root=run_root,
+                in_root=Path(args.in_path),
+                out_root=Path(args.out_path),
+                scan_roots=scan_roots,
+                doctype_registry=doctype_registry,
+                adv_cfg_path=Path(args.adversarial_config) if args.adversarial_config else None,
+                bumper=bumper,
+                cycles=args.cycles,
+                eps=args.eps,
+                stable_n=args.stable_n,
+                adversarial=args.adversarial,
+                adv_cycles=args.adv_cycles,
+                adv_eps=args.adv_eps,
+                adv_stable_n=args.adv_stable_n,
+                web_enabled=boolish(args.web),
+                max_files=args.max_files,
+                excludes=args.exclude,
+                max_fetch=args.max_fetch
+            )
+        except Exception as e:
+            bumper.add("WATCH_RUN_FAIL", "watch_cycle", {"error": repr(e)})
+
+    observer = Observer()
+    for r in scan_roots:
+        if r.exists():
+            observer.schedule(_WatchHandler(trigger), str(r), recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+# ----------------------------
+# CLI
+# ----------------------------
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="mcl_plane_suite.py")
+    p.add_argument("--in", dest="in_path", default="IN", help="Input root (default IN)")
+    p.add_argument("--out", dest="out_path", default="OUT", help="Output root (default OUT)")
+    p.add_argument("--mode", choices=["once", "converge", "watch"], default="converge")
+    p.add_argument("--cycles", type=int, default=25)
+    p.add_argument("--eps", type=int, default=0, help="Convergence epsilon (delta <= eps)")
+    p.add_argument("--stable-n", type=int, default=3, help="Stable cycles required to stop")
+    p.add_argument("--adversarial", type=str, default="true", help="Enable adversarial scan (true/false)")
+    p.add_argument("--adversarial-config", default="", help="Optional path to adversarial_config.json")
+    p.add_argument("--adv-cycles", type=int, default=10, help="Inner adversarial convergence cycles")
+    p.add_argument("--adv-eps", type=int, default=0, help="Inner adversarial convergence eps")
+    p.add_argument("--adv-stable-n", type=int, default=3, help="Inner adversarial stable cycles to stop")
+    p.add_argument("--web", type=str, default="true", help="Enable web harvest (true/false)")
+    p.add_argument("--doctype-registry", default="", help="Optional path to doctype_registry.json")
+    p.add_argument("--scan-root", action="append", default=[], help="Root to scan (repeatable). Default: IN only.")
+    p.add_argument("--scan-all-drives", action="store_true", help="Windows: scan all fixed drives (C:,D:,E:...).")
+    p.add_argument("--max-files", type=int, default=200000, help="Max files to enumerate (0 = unlimited)")
+    p.add_argument("--hash-files", type=str, default="true", help="Hash files for evidence index (true/false)")
+    p.add_argument("--exclude", action="append", default=[], help="Regex exclude (repeatable)")
+    p.add_argument("--max-fetch", type=int, default=40, help="Max URLs fetched per outer cycle")
+    return p.parse_args(argv)
+
+
+def boolish(s: str) -> bool:
+    return str(s).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def windows_drive_roots(bumper: BumperLog) -> List[Path]:
+    roots = []
+    for letter in "CDEFGHIJKLMNOPQRSTUVWXYZ":
+        p = Path(f"{letter}:/")
+        if p.exists():
+            roots.append(p)
+    if not roots:
+        bumper.add("NO_WINDOWS_DRIVES_FOUND", "scan-all-drives", {})
+    return roots
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    bumper = BumperLog()
+
+    in_root = Path(getattr(args, "in_path")).resolve()
+    out_root = Path(getattr(args, "out_path")).resolve()
+
+    ensure_dir(in_root)
+    ensure_dir(out_root)
+    ensure_dir(out_root / "RUNS")
+    ensure_dir(out_root / "schema")
+    ensure_dir(out_root / "queries")
+    ensure_dir(out_root / "seeds")
+
+    dr_path = out_root / "schema" / "doctype_registry.json"
+    if not dr_path.exists():
+        write_json(dr_path, DEFAULT_DOCTYPE_REGISTRY)
+    mv_path = out_root / "schema" / "event_to_mv_mapping.json"
+    if not mv_path.exists():
+        write_json(mv_path, DEFAULT_EVENT_TO_MV)
+    cy_path = out_root / "queries" / "bumper_query_pack.cypher"
+    if not cy_path.exists():
+        cy_path.write_text("// See suite README for query pack.\n", encoding="utf-8", newline="\n")
+
+    doctype_registry = load_doctype_registry(Path(args.doctype_registry) if args.doctype_registry else None, bumper)
+
+    if args.scan_root:
+        scan_roots = [Path(x) for x in args.scan_root]
+    elif args.scan_all_drives and sys.platform.startswith("win"):
+        scan_roots = windows_drive_roots(bumper)
+    else:
+        scan_roots = [in_root]
+
+    default_ex = [
+        r"/windows/", r"/program files", r"/programdata/", r"/appdata/",
+        r"/\$recycle\.bin", r"/system volume information", r"/node_modules/",
+        r"/\.git/", r"/\.venv/", r"/venv/", r"/__pycache__/", r"/dist/", r"/build/",
+    ]
+    excludes = default_ex + (args.exclude or [])
+
+    adversarial = boolish(args.adversarial)
+
+    if args.mode == "watch":
+        watch_and_incremental(args, scan_roots, doctype_registry, bumper)
+        return 0
+
+    run_id = mk_run_id()
+    run_root = out_root / "RUNS" / run_id
+    ensure_dir(run_root)
+
+    converge(
+        run_root=run_root,
+        in_root=in_root,
+        out_root=out_root,
+        scan_roots=scan_roots,
+        doctype_registry=doctype_registry,
+        adv_cfg_path=Path(args.adversarial_config) if args.adversarial_config else None,
+        bumper=bumper,
+        cycles=max(1, int(args.cycles)),
+        eps=int(args.eps),
+        stable_n=max(1, int(args.stable_n)),
+        adversarial=adversarial,
+        adv_cycles=max(1, int(args.adv_cycles)),
+        adv_eps=int(args.adv_eps),
+        adv_stable_n=max(1, int(args.adv_stable_n)),
+        web_enabled=boolish(args.web),
+        max_files=int(args.max_files),
+        excludes=excludes,
+        max_fetch=int(args.max_fetch),
+        hash_files=boolish(args.hash_files),
+    )
+    print(f"[OK] Run complete: {run_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/OUT/queries/bumper_query_pack.cypher
+++ b/OUT/queries/bumper_query_pack.cypher
@@ -1,0 +1,1 @@
+// See suite README for query pack.

--- a/OUT/schema/doctype_registry.json
+++ b/OUT/schema/doctype_registry.json
@@ -1,0 +1,22 @@
+{
+  "version": "v1",
+  "generated_utc": "2026-01-26T00:00:00Z",
+  "buckets_max": 15,
+  "buckets": [
+    {"bucket":"B01_TEXT","ext":[".txt",".md",".log"],"extractor":"text"},
+    {"bucket":"B02_STRUCTURED","ext":[".json",".jsonl",".csv",".tsv",".xml",".yaml",".yml"],"extractor":"structured"},
+    {"bucket":"B03_HTML","ext":[".html",".htm"],"extractor":"html_text"},
+    {"bucket":"B04_DOCX","ext":[".docx"],"extractor":"docx_optional"},
+    {"bucket":"B05_RTF","ext":[".rtf"],"extractor":"rtf_optional"},
+    {"bucket":"B06_PDF_TEXT","ext":[".pdf"],"extractor":"pdf_optional"},
+    {"bucket":"B07_IMAGES","ext":[".jpg",".jpeg",".png",".webp",".tif",".tiff"],"extractor":"none"},
+    {"bucket":"B08_AUDIO","ext":[".mp3",".wav",".m4a",".aac",".flac"],"extractor":"none"},
+    {"bucket":"B09_VIDEO","ext":[".mp4",".mov",".mkv",".avi"],"extractor":"none"},
+    {"bucket":"B10_ARCHIVE","ext":[".zip",".7z",".rar"],"extractor":"archive_optional"},
+    {"bucket":"B11_CODE","ext":[".py",".ps1",".bat",".cmd",".js",".ts",".tsx",".jsx",".java",".cs",".cpp",".c",".rs",".go"],"extractor":"code_text"},
+    {"bucket":"B12_OFFICE_OTHER","ext":[".doc",".xls",".xlsx",".ppt",".pptx"],"extractor":"optional"},
+    {"bucket":"B13_EMAIL","ext":[".eml",".msg"],"extractor":"optional"},
+    {"bucket":"B14_DATABASE","ext":[".db",".sqlite",".edb"],"extractor":"none"},
+    {"bucket":"B15_OTHER","ext":["*"],"extractor":"none"}
+  ]
+}

--- a/OUT/schema/event_to_mv_mapping.json
+++ b/OUT/schema/event_to_mv_mapping.json
@@ -1,0 +1,33 @@
+{
+  "version": "v1",
+  "mv_taxonomy": {
+    "MV01": "Bias/Partiality",
+    "MV02": "Weaponized_PPO",
+    "MV03": "Retaliatory_Contempt",
+    "MV04": "DueProcess_Denial",
+    "MV05": "Evidentiary_Asymmetry",
+    "MV06": "ParentingTime_Interference",
+    "MV07": "Procedural_Barrier",
+    "MV08": "Record_Tampering_Omission",
+    "MV09": "False_Report_Pattern",
+    "MV10": "Coercive_Settlement_Threats"
+  },
+  "category_to_mv": {
+    "JUDICIAL_BIAS": "MV01",
+    "CREDIBILITY_ATTACK": "MV01",
+    "EX_PARTE_ABUSE": "MV04",
+    "DUE_PROCESS": "MV04",
+    "DENIAL_OF_EVIDENCE": "MV05",
+    "DENIAL_OF_WITNESS": "MV05",
+    "PPO_WEAPONIZATION": "MV02",
+    "CONTEMPT_ABUSE": "MV03",
+    "PARENTING_TIME_WITHHELD": "MV06",
+    "BOND_BARRIER": "MV07",
+    "NOTICE_DEFECT": "MV04",
+    "HEARSAY_RELIANCE": "MV05",
+    "FALSE_REPORT": "MV09",
+    "THREAT_OR_EXTORTION": "MV10",
+    "MENTAL_HEALTH_SMEAR": "MV01",
+    "SUBSTANCE_ABUSE_SMEAR": "MV01"
+  }
+}

--- a/OUT/seeds/seed_urls.txt
+++ b/OUT/seeds/seed_urls.txt
@@ -1,0 +1,5 @@
+https://www.legislature.mi.gov/
+https://www.legislature.mi.gov/Laws/MCL
+https://www.legislature.mi.gov/Laws/ChapterIndex
+https://www.legislature.mi.gov/Bills
+https://www.legislature.mi.gov/Committees

--- a/organize_drive.ps1
+++ b/organize_drive.ps1
@@ -1,114 +1,517 @@
-<#
-.SYNOPSIS
-Organizes files in a drive into categorized folders and removes empty directories.
-#>
+& {
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
-param(
-    [string]$Path = 'F:\',
-    [string]$Log = 'organize_drive.log',
-    [string]$Output = '',  # Optional custom output directory
-    [int]$MaxJobs = [Environment]::ProcessorCount
-)
+    # =========================
+    # CONFIG
+    # =========================
+    $SourceRoots = @(
+        'C:\Users\andrew'
+    )
 
-$ErrorActionPreference = 'Stop'
+    # Change if you want a different destination root
+    $DestinationRoot = 'E:\FileHistory\andre\THEMANBEARPIG\_ORGANIZED_BY_EXT_FROM_C_USERS_ANDREW'
 
-Start-Transcript -Path $Log -Append
+    $DoMove = $false                      # $false = COPY, $true = MOVE (COPY recommended initially)
+    $Dedupe = $true                       # exact duplicates by SHA-256
+    $DedupeAction = 'Quarantine'          # 'Quarantine' | 'Skip' | 'KeepAll'
+    $RemoveEmptySourceFolders = $false    # Only consider with MOVE, and only after you verify results
+    $SkipReparsePoints = $true            # skips junctions/symlinks to avoid loops
+    $ComputeSHA256 = $true                # required for dedupe
+    $RunSelfTest = $true                  # validates logic in a sandbox before touching your data
+    $SelfTestRuns = 10                    # repeat self-test N times for confidence
+    $SelfTestOnly = $false                # if true, exit after self-test without organizing
+    $RunManifestPath = ''                 # optional path to write a run manifest JSON
 
-$Categories = @{
-    'Documents' = '.pdf','.doc','.docx','.txt','.xls','.xlsx','.ppt','.pptx','.csv','.odt','.ods','.odp'
-    'Images'    = '.jpg','.jpeg','.png','.gif','.bmp','.tiff','.svg'
-    'Music'     = '.mp3','.wav','.flac','.aac','.ogg','.wma'
-    'Videos'    = '.mp4','.avi','.mkv','.mov','.wmv','.flv'
-    'Archives'  = '.zip','.rar','.7z','.tar','.gz','.bz2'
-    'Code'      = '.py','.js','.html','.css','.java','.c','.cpp','.cs','.rb','.php'
-}
+    # Optional environment overrides (useful for CI/self-test runs)
+    if ($env:ORGDRIVE_SELFTEST_ONLY) { $SelfTestOnly = $env:ORGDRIVE_SELFTEST_ONLY -in @('1', 'true', 'TRUE') }
+    if ($env:ORGDRIVE_SELFTEST_RUNS) { $SelfTestRuns = [int]$env:ORGDRIVE_SELFTEST_RUNS }
+    if ($env:ORGDRIVE_RUN_SELFTEST) { $RunSelfTest = $env:ORGDRIVE_RUN_SELFTEST -in @('1', 'true', 'TRUE') }
 
-$DefaultCategory = 'Other'
-$OrganizedFolder = 'Organized'
+    # Exclusions inside your canonical folder (safe defaults)
+    $ExcludeRoots = @(
+        'C:\Users\andrew\AppData',
+        'C:\Users\andrew\OneDriveTemp',
+        'C:\Users\andrew\.cache',
+        'C:\Users\andrew\.nuget',
+        'C:\Users\andrew\.vscode',
+        'C:\Users\andrew\.git'
+    )
 
-function Get-Category {
-    param([string]$Extension)
-    foreach ($cat in $Categories.Keys) {
-        if ($Categories[$cat] -contains $Extension.ToLower()) {
-            return $cat
+    # =========================
+    # Helpers
+    # =========================
+    function Ensure-Dir([string]$Path) {
+        if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+    }
+
+    function Normalize-Root([string]$p) {
+        if ([string]::IsNullOrWhiteSpace($p)) { return $null }
+        $full = [System.IO.Path]::GetFullPath($p)
+        if ($full.EndsWith('\')) { return $full }
+        return $full + '\'
+    }
+
+    function Build-ExcludeList([string[]]$Roots) {
+        $list = New-Object System.Collections.Generic.List[string]
+        foreach ($r in $Roots) {
+            try {
+                $nr = Normalize-Root $r
+                if ($nr) { $list.Add($nr) }
+            } catch { }
+        }
+        return $list.ToArray()
+    }
+
+    function Is-ExcludedPath([string]$Path, [string[]]$ExcludeNorm) {
+        if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+        $p = $Path
+        if (-not $p.EndsWith('\')) { $p = $p + '\' }
+        foreach ($ex in $ExcludeNorm) {
+            if ($p.StartsWith($ex, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+        }
+        return $false
+    }
+
+    function To-LongPath([string]$Path) {
+        if ($Path -like '\\?\*') { return $Path }
+        if ($Path -like '\\*') { return "\\?\UNC\" + $Path.TrimStart('\\') }
+        return "\\?\" + $Path
+    }
+
+    function Get-StringMD5([string]$InputString) {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($InputString)
+            $hashBytes = $md5.ComputeHash($bytes)
+            return -join ($hashBytes | ForEach-Object { $_.ToString('x2') })
+        } finally { $md5.Dispose() }
+    }
+
+    function Get-FileSHA256([string]$Path) {
+        return (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash
+    }
+
+    function CopyOrMove-File([string]$Src, [string]$Dst, [bool]$Move) {
+        try {
+            if ($Move) { Move-Item -LiteralPath $Src -Destination $Dst -Force -ErrorAction Stop }
+            else { Copy-Item -LiteralPath $Src -Destination $Dst -Force -ErrorAction Stop }
+            return $true
+        } catch {
+            try {
+                $srcLP = To-LongPath $Src
+                $dstLP = To-LongPath $Dst
+                if ($Move) { [System.IO.File]::Move($srcLP, $dstLP) }
+                else { [System.IO.File]::Copy($srcLP, $dstLP, $true) }
+                return $true
+            } catch {
+                return $false
+            }
         }
     }
-    return $DefaultCategory
-}
 
-function Safe-Move {
-    param([string]$Source, [string]$Destination)
-    $destDir = Split-Path $Destination -Parent
-    if (!(Test-Path $destDir)) { New-Item -ItemType Directory -Path $destDir | Out-Null }
-    $base = [System.IO.Path]::GetFileNameWithoutExtension($Destination)
-    $ext  = [System.IO.Path]::GetExtension($Destination)
-    $dest = $Destination
-    $counter = 1
-    while (Test-Path $dest) {
-        $dest = Join-Path $destDir "${base}_${counter}${ext}"
-        $counter++
+    function Get-FilesSafe([string]$Root, [bool]$SkipReparse, [string[]]$ExcludeNorm) {
+        $rootFull = [System.IO.Path]::GetFullPath($Root)
+        if (Is-ExcludedPath -Path $rootFull -ExcludeNorm $ExcludeNorm) { return }
+
+        $rootDI = New-Object System.IO.DirectoryInfo($rootFull)
+        $stack = New-Object System.Collections.Stack
+        $stack.Push($rootDI)
+
+        while ($stack.Count -gt 0) {
+            $dir = $stack.Pop()
+            try {
+                if (Is-ExcludedPath -Path $dir.FullName -ExcludeNorm $ExcludeNorm) { continue }
+
+                foreach ($sub in $dir.GetDirectories()) {
+                    if ($SkipReparse -and (($sub.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) { continue }
+                    if (Is-ExcludedPath -Path $sub.FullName -ExcludeNorm $ExcludeNorm) { continue }
+                    $stack.Push($sub)
+                }
+
+                foreach ($file in $dir.GetFiles()) {
+                    if ($SkipReparse -and (($file.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) { continue }
+                    $file
+                }
+            } catch {
+                continue
+            }
+        }
     }
-    Move-Item -LiteralPath $Source -Destination $dest
-}
 
-function Remove-EmptyDirs {
-    param([string]$BasePath)
-    Get-ChildItem -Path $BasePath -Directory -Recurse |
-        Sort-Object -Property FullName -Descending |
-        ForEach-Object {
-            if (-not (Get-ChildItem -LiteralPath $_.FullName -Recurse -Force)) {
+    function Remove-EmptyDirs([string[]]$Roots, [string[]]$ExcludeNorm) {
+        foreach ($r in $Roots) {
+            if (-not (Test-Path -LiteralPath $r)) { continue }
+            $rFull = [System.IO.Path]::GetFullPath($r)
+            if (Is-ExcludedPath -Path $rFull -ExcludeNorm $ExcludeNorm) { continue }
+
+            $dirs = Get-ChildItem -LiteralPath $rFull -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+                Sort-Object { $_.FullName.Length } -Descending
+
+            foreach ($d in $dirs) {
                 try {
-                    Remove-Item -LiteralPath $_.FullName -Force
-                    Write-Host "Removed empty directory $($_.FullName)"
-                } catch {
-                    Write-Warning "Failed to remove $($_.FullName): $_"
+                    if (Is-ExcludedPath -Path $d.FullName -ExcludeNorm $ExcludeNorm) { continue }
+                    $hasFiles = Get-ChildItem -LiteralPath $d.FullName -File -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+                    $hasDirs  = Get-ChildItem -LiteralPath $d.FullName -Directory -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+                    if (-not $hasFiles -and -not $hasDirs) {
+                        Remove-Item -LiteralPath $d.FullName -Force -ErrorAction SilentlyContinue
+                    }
+                } catch { }
+            }
+        }
+    }
+
+    function Write-RowCsv([string]$CsvPath, [object]$Obj) {
+        if (-not (Test-Path -LiteralPath $CsvPath)) {
+            $Obj | Export-Csv -LiteralPath $CsvPath -NoTypeInformation -Encoding UTF8
+        } else {
+            $Obj | Export-Csv -LiteralPath $CsvPath -NoTypeInformation -Append -Encoding UTF8
+        }
+    }
+
+    function Write-RowJsonl([string]$JsonlPath, [object]$Obj) {
+        ($Obj | ConvertTo-Json -Compress) | Add-Content -LiteralPath $JsonlPath -Encoding UTF8
+    }
+
+    function Get-ExtBucket([System.IO.FileInfo]$File) {
+        $ext = $File.Extension
+        if ([string]::IsNullOrWhiteSpace($ext)) { return '_no_extension' }
+        $clean = $ext.TrimStart('.').ToLowerInvariant()
+        if ([string]::IsNullOrWhiteSpace($clean)) { return '_no_extension' }
+        return $clean
+    }
+
+    function Get-UniqueDestName([System.IO.FileInfo]$File, [string]$SrcLeaf) {
+        $pathHash = (Get-StringMD5 -InputString $File.FullName).Substring(0, 10)
+        return "{0}__{1}__{2}" -f $SrcLeaf, $pathHash, $File.Name
+    }
+
+    function Invoke-OrganizeByExtension {
+        param(
+            [string[]]$Sources,
+            [string]$DestRoot,
+            [bool]$MoveMode,
+            [bool]$DoDedupe,
+            [string]$DupAction,
+            [bool]$SkipReparse,
+            [bool]$DoHash,
+            [string[]]$ExcludeNorm
+        )
+
+        Ensure-Dir $DestRoot
+        $logsDir = Join-Path $DestRoot '__LOGS'
+        $dupsDir = Join-Path $DestRoot '__DUPLICATES'
+        Ensure-Dir $logsDir
+        if ($DoDedupe -and ($DupAction -eq 'Quarantine')) { Ensure-Dir $dupsDir }
+
+        $ts = (Get-Date).ToString('yyyyMMdd_HHmmss')
+        $csvLog = Join-Path $logsDir ("organize_by_ext_{0}.csv" -f $ts)
+        $jsonl  = Join-Path $logsDir ("organize_by_ext_{0}.jsonl" -f $ts)
+
+        $hashIndex = @{}   # sha256 -> primary dest path
+        $counts = @{
+            COPIED = 0; MOVED = 0; DUP_SKIPPED = 0; DUP_QUARANTINED = 0; FAILED = 0; SOURCE_MISSING = 0
+        }
+
+        foreach ($srcRoot in $Sources) {
+            if ([string]::IsNullOrWhiteSpace($srcRoot)) { continue }
+            if (-not (Test-Path -LiteralPath $srcRoot)) {
+                $counts.SOURCE_MISSING++
+                $row = [pscustomobject]@{
+                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                    action   = 'SOURCE_MISSING'
+                    source_root = $srcRoot
+                    source   = $null
+                    dest     = $null
+                    ext      = $null
+                    bytes    = $null
+                    sha256   = $null
+                    note     = $null
+                    error    = $null
+                }
+                Write-RowCsv  $csvLog $row
+                Write-RowJsonl $jsonl $row
+                continue
+            }
+
+            $srcLeaf = Split-Path -Path $srcRoot -Leaf
+            if ([string]::IsNullOrWhiteSpace($srcLeaf)) { $srcLeaf = 'andrew' }
+
+            $files = @(Get-FilesSafe -Root $srcRoot -SkipReparse:$SkipReparse -ExcludeNorm $ExcludeNorm)
+
+            foreach ($f in $files) {
+                $extBucket = Get-ExtBucket $f
+                $extDir = Join-Path $DestRoot $extBucket
+                Ensure-Dir $extDir
+
+                $destName = Get-UniqueDestName -File $f -SrcLeaf $srcLeaf
+                $destPath = Join-Path $extDir $destName
+
+                $sha = $null
+                if ($DoHash -or $DoDedupe) {
+                    try { $sha = Get-FileSHA256 -Path $f.FullName } catch { $sha = $null }
+                }
+
+                if ($DoDedupe -and $sha) {
+                    if ($hashIndex.ContainsKey($sha)) {
+                        if ($DupAction -eq 'Skip') {
+                            $counts.DUP_SKIPPED++
+                            $row = [pscustomobject]@{
+                                time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                action   = 'DUPLICATE_SKIPPED'
+                                source_root = $srcRoot
+                                source   = $f.FullName
+                                dest     = $null
+                                ext      = $extBucket
+                                bytes    = $f.Length
+                                sha256   = $sha
+                                note     = "primary=" + $hashIndex[$sha]
+                                error    = $null
+                            }
+                            Write-RowCsv  $csvLog $row
+                            Write-RowJsonl $jsonl $row
+                            continue
+                        }
+
+                        if ($DupAction -eq 'Quarantine') {
+                            $qDir = Join-Path $dupsDir $extBucket
+                            Ensure-Dir $qDir
+                            $qPath = Join-Path $qDir $destName
+
+                            $okQ = CopyOrMove-File -Src $f.FullName -Dst $qPath -Move:$MoveMode
+                            if ($okQ) {
+                                $counts.DUP_QUARANTINED++
+                                $row = [pscustomobject]@{
+                                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                    action   = $(if ($MoveMode) { 'DUPLICATE_MOVED_TO_QUARANTINE' } else { 'DUPLICATE_COPIED_TO_QUARANTINE' })
+                                    source_root = $srcRoot
+                                    source   = $f.FullName
+                                    dest     = $qPath
+                                    ext      = $extBucket
+                                    bytes    = $f.Length
+                                    sha256   = $sha
+                                    note     = "primary=" + $hashIndex[$sha]
+                                    error    = $null
+                                }
+                                Write-RowCsv  $csvLog $row
+                                Write-RowJsonl $jsonl $row
+                                continue
+                            } else {
+                                $counts.FAILED++
+                                $row = [pscustomobject]@{
+                                    time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                                    action   = 'FAILED_DUP_QUARANTINE'
+                                    source_root = $srcRoot
+                                    source   = $f.FullName
+                                    dest     = $qPath
+                                    ext      = $extBucket
+                                    bytes    = $f.Length
+                                    sha256   = $sha
+                                    note     = "primary=" + $hashIndex[$sha]
+                                    error    = 'CopyOrMove failed'
+                                }
+                                Write-RowCsv  $csvLog $row
+                                Write-RowJsonl $jsonl $row
+                                continue
+                            }
+                        }
+                    }
+                }
+
+                $ok = CopyOrMove-File -Src $f.FullName -Dst $destPath -Move:$MoveMode
+                if ($ok) {
+                    if ($MoveMode) { $counts.MOVED++ } else { $counts.COPIED++ }
+                    if ($DoDedupe -and $sha -and (-not $hashIndex.ContainsKey($sha))) { $hashIndex[$sha] = $destPath }
+
+                    $row = [pscustomobject]@{
+                        time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                        action   = $(if ($MoveMode) { 'MOVED' } else { 'COPIED' })
+                        source_root = $srcRoot
+                        source   = $f.FullName
+                        dest     = $destPath
+                        ext      = $extBucket
+                        bytes    = $f.Length
+                        sha256   = $sha
+                        note     = $null
+                        error    = $null
+                    }
+                    Write-RowCsv  $csvLog $row
+                    Write-RowJsonl $jsonl $row
+                } else {
+                    $counts.FAILED++
+                    $row = [pscustomobject]@{
+                        time_utc = (Get-Date).ToUniversalTime().ToString('o')
+                        action   = 'FAILED'
+                        source_root = $srcRoot
+                        source   = $f.FullName
+                        dest     = $destPath
+                        ext      = $extBucket
+                        bytes    = $f.Length
+                        sha256   = $sha
+                        note     = $null
+                        error    = 'CopyOrMove failed'
+                    }
+                    Write-RowCsv  $csvLog $row
+                    Write-RowJsonl $jsonl $row
                 }
             }
         }
-}
 
-function Move-FileJob {
-    param($File, $BaseOutput)
+        $indexPath = Join-Path $logsDir ("index_by_ext_{0}.csv" -f $ts)
+        $extDirs = Get-ChildItem -LiteralPath $DestRoot -Directory -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notin @('__LOGS','__DUPLICATES') }
+
+        $idxRows = foreach ($d in $extDirs) {
+            $files = @(Get-ChildItem -LiteralPath $d.FullName -File -Force -ErrorAction SilentlyContinue)
+            $total = 0L
+            foreach ($ff in $files) { $total += [int64]$ff.Length }
+            [pscustomobject]@{
+                ext_bucket  = $d.Name
+                file_count  = $files.Count
+                total_bytes = $total
+                folder      = $d.FullName
+            }
+        }
+        $idxRows | Sort-Object file_count -Descending | Export-Csv -LiteralPath $indexPath -NoTypeInformation -Encoding UTF8
+
+        return [pscustomobject]@{
+            DestinationRoot = $DestRoot
+            CsvLog          = $csvLog
+            JsonlLog        = $jsonl
+            IndexByExt      = $indexPath
+            Counts          = $counts
+        }
+    }
+
+    function Invoke-SelfTest {
+        $guid = [Guid]::NewGuid().ToString('N')
+        $base = Join-Path $env:TEMP ("OrgByExt_SelfTest_{0}" -f $guid)
+        $src1 = Join-Path $base 'src1'
+        $src2 = Join-Path $base 'src2'
+        $dst  = Join-Path $base 'dst'
+
+        $exNorm = Build-ExcludeList -Roots @()
+
+        try {
+            Ensure-Dir $src1
+            Ensure-Dir $src2
+            Ensure-Dir $dst
+            Ensure-Dir (Join-Path $src1 'nested')
+            Ensure-Dir (Join-Path $src2 'nested')
+
+            Set-Content -LiteralPath (Join-Path $src1 'a.txt') -Value 'same-content' -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'b.txt') -Value 'same-content' -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src1 'c.pdf') -Value 'pdf-content'  -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'd')     -Value 'noext'        -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src1 'nested\e.jpg') -Value 'img'  -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path $src2 'nested\f.jpg') -Value 'img2' -Encoding UTF8
+
+            $r = Invoke-OrganizeByExtension -Sources @($src1,$src2) -DestRoot $dst -MoveMode:$false -DoDedupe:$true -DupAction:'Quarantine' -SkipReparse:$true -DoHash:$true -ExcludeNorm $exNorm
+
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'txt'))) { throw 'SelfTest: missing txt folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'pdf'))) { throw 'SelfTest: missing pdf folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst 'jpg'))) { throw 'SelfTest: missing jpg folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path $dst '_no_extension'))) { throw 'SelfTest: missing _no_extension folder' }
+            if (-not (Test-Path -LiteralPath (Join-Path (Join-Path $dst '__DUPLICATES') 'txt'))) { throw 'SelfTest: missing dup quarantine txt folder' }
+            if (-not (Test-Path -LiteralPath $r.CsvLog)) { throw 'SelfTest: missing CSV log' }
+            if (-not (Test-Path -LiteralPath $r.IndexByExt)) { throw 'SelfTest: missing index_by_ext CSV' }
+
+            $txtPrimary = @(Get-ChildItem -LiteralPath (Join-Path $dst 'txt') -File -Force -ErrorAction SilentlyContinue)
+            $txtDup = @(Get-ChildItem -LiteralPath (Join-Path (Join-Path $dst '__DUPLICATES') 'txt') -File -Force -ErrorAction SilentlyContinue)
+            if ($txtPrimary.Count -ne 1) { throw "SelfTest: expected 1 primary txt file, got $($txtPrimary.Count)" }
+            if ($txtDup.Count -ne 1) { throw "SelfTest: expected 1 quarantined dup txt file, got $($txtDup.Count)" }
+
+            return $true
+        } finally {
+            try { Remove-Item -LiteralPath $base -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+        }
+    }
+
+    # =========================
+    # MAIN
+    # =========================
     try {
-        $category = Get-Category $File.Extension
-        $destDir = Join-Path $BaseOutput $category
-        $destination = Join-Path $destDir $File.Name
-        Safe-Move -Source $File.FullName -Destination $destination
-        Write-Host "Moved $($File.FullName) -> $destination"
-    } catch {
-        Write-Warning "Failed to move $($File.FullName): $_"
+        if ($Dedupe -and ($DedupeAction -notin @('Quarantine','Skip','KeepAll'))) {
+            throw "Invalid DedupeAction. Use: Quarantine, Skip, KeepAll."
+        }
+
+        $excludeNorm = Build-ExcludeList -Roots $ExcludeRoots
+
+        Write-Host "Organize start : $([DateTime]::Now.ToString('o'))"
+        Write-Host "Source         : C:\Users\andrew"
+        Write-Host "Mode           : $(if ($DoMove) { 'MOVE' } else { 'COPY' })"
+        Write-Host "Destination    : $DestinationRoot"
+        Write-Host "Group by ext   : YES"
+        Write-Host "Dedupe         : $Dedupe"
+        Write-Host "DedupeAction   : $DedupeAction"
+        Write-Host "Skip reparse   : $SkipReparsePoints"
+        Write-Host "Exclude roots  :"
+        foreach ($x in $excludeNorm) { Write-Host "  - $x" }
+        Write-Host ""
+
+        if ($RunSelfTest) {
+            for ($i = 1; $i -le $SelfTestRuns; $i++) {
+                Write-Host "Self-test (temp sandbox) running... ($i/$SelfTestRuns)"
+                $ok = Invoke-SelfTest
+                if (-not $ok) { throw "Self-test returned failure." }
+            }
+            Write-Host "Self-test: PASS ($SelfTestRuns runs)"
+            Write-Host ""
+            if ($SelfTestOnly) {
+                Write-Host "Self-test-only mode enabled. Exiting."
+                return
+            }
+        }
+
+        Ensure-Dir $DestinationRoot
+
+        $result = Invoke-OrganizeByExtension `
+            -Sources $SourceRoots `
+            -DestRoot $DestinationRoot `
+            -MoveMode:$DoMove `
+            -DoDedupe:$Dedupe `
+            -DupAction:$DedupeAction `
+            -SkipReparse:$SkipReparsePoints `
+            -DoHash:$ComputeSHA256 `
+            -ExcludeNorm $excludeNorm
+
+        if ($DoMove -and $RemoveEmptySourceFolders) {
+            Write-Host "Removing empty folders under source roots (excluding protected roots)..."
+            Remove-EmptyDirs -Roots $SourceRoots -ExcludeNorm $excludeNorm
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($RunManifestPath)) {
+            $manifest = [pscustomobject]@{
+                generated_utc     = (Get-Date).ToUniversalTime().ToString('o')
+                sources           = $SourceRoots
+                destination       = $DestinationRoot
+                move_mode         = $DoMove
+                dedupe            = $Dedupe
+                dedupe_action     = if ($Dedupe) { $DedupeAction } else { 'OFF' }
+                remove_empty_dirs = $RemoveEmptySourceFolders
+                exclude_roots     = $excludeNorm
+                logs              = [pscustomobject]@{
+                    csv_log   = $result.CsvLog
+                    jsonl_log = $result.JsonlLog
+                    index_csv = $result.IndexByExt
+                }
+                counts            = $result.Counts
+            }
+            $manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $RunManifestPath -Encoding UTF8
+        }
+
+        Write-Host ""
+        Write-Host "Organize complete: $([DateTime]::Now.ToString('o'))"
+        Write-Host "Destination      : $($result.DestinationRoot)"
+        Write-Host "Index (by ext)   : $($result.IndexByExt)"
+        Write-Host "CSV Log          : $($result.CsvLog)"
+        Write-Host "JSONL Log        : $($result.JsonlLog)"
+        Write-Host "Counts           : COPIED=$($result.Counts.COPIED) MOVED=$($result.Counts.MOVED) DUP_SKIPPED=$($result.Counts.DUP_SKIPPED) DUP_QUARANTINED=$($result.Counts.DUP_QUARANTINED) FAILED=$($result.Counts.FAILED) SOURCE_MISSING=$($result.Counts.SOURCE_MISSING)"
+    }
+    catch {
+        Write-Host ""
+        Write-Host "FATAL: $($_.Exception.Message)"
+        Write-Host "STACK: $($_.ScriptStackTrace)"
+        throw
     }
 }
-
-$target = Resolve-Path $Path
-if ($Output) {
-    $baseOutput = Resolve-Path $Output
-} else {
-    $baseOutput = Join-Path $target $OrganizedFolder
-}
-if (!(Test-Path $baseOutput)) { New-Item -ItemType Directory -Path $baseOutput | Out-Null }
-
-$files = Get-ChildItem -Path $target -File -Recurse | Where-Object { $_.FullName -notmatch "\\$OrganizedFolder(\\|$)" }
-$total = $files.Count
-$index = 0
-
-Import-Module ThreadJob -ErrorAction SilentlyContinue
-$jobs = @()
-foreach ($f in $files) {
-    $index++
-    $percent = [int](($index / $total) * 100)
-    Write-Progress -Activity "Organizing files" -Status "$index of $total" -PercentComplete $percent
-    $jobs += Start-ThreadJob -ScriptBlock ${function:Move-FileJob} -ArgumentList $f, $baseOutput
-    if ($jobs.Count -ge $MaxJobs) {
-        Wait-Job -Job $jobs -Any | Receive-Job
-        $jobs = $jobs | Where-Object { $_.State -eq 'Running' }
-    }
-}
-
-if ($jobs) { Wait-Job $jobs | Receive-Job }
-Write-Progress -Activity "Organizing files" -Completed
-
-Remove-EmptyDirs -BasePath $target
-
-Stop-Transcript
-Write-Host 'Organization complete.'


### PR DESCRIPTION
### Motivation
- Improve traceability and reproducibility of adversarial findings by adding file-level evidence indexing, stable hashes, and precise snippet offsets so downstream artifacts (CSV/Neo4j/JSONL) are cite-able and audit-ready.
- Provide a local-first graph and packaging pipeline and a hardened, auditable organizer to support deterministic analysis, non-destructive operations, and resumable apply/playbook behavior.
- Replace fragile scripts with self-testing, long-path-aware, dedupe-capable tooling and lightweight launchers to simplify runs and CI usage.

### Description
- Updated `OUT/code/mcl_plane_suite.py` to add `sha256_file`, build an `evidence_index` (`RUN/evidence_index.jsonl`), include `offset_start`/`offset_end` and `snippet_hash` for adversarial findings, make Neo4j CSV export include file SHA256, and emit a `run_manifest.json` with inputs/features/counts; timestamps use timezone-aware UTC formatting now.
- Added `LITIGATIONOS_DRIVE_BUCKET_FORGER_v2026_01_27D.py` as a new Drive Bucket Forger implementing inventory/virtualization/graph pipeline, dedupe/version heuristics, adversarial content flagging, and multiple export formats (JSONL/CSV/SQLite/Neo4j) with deterministic IDs and ERD artifacts.
- Rewrote `organize_drive.ps1` into a resilient, long-path-friendly organizer with `To-LongPath`, `Get-FilesSafe`, `CopyOrMove-File`, SHA256 dedupe/quarantine/skip/keep behaviors, CSV/JSONL logging, `Invoke-SelfTest` sandbox harness, environment overrides, and optional run manifest output.
- Added convenience launchers and schema/support assets: `LAUNCH.bat`, `LAUNCH.ps1`, `OUT/schema/doctype_registry.json`, `OUT/schema/event_to_mv_mapping.json`, `OUT/queries/bumper_query_pack.cypher`, and `OUT/seeds/seed_urls.txt` to seed web harvests.

### Testing
- Ran static compile check with `python -m py_compile OUT/code/mcl_plane_suite.py`, which completed successfully with no syntax errors.
- Executed the suite end-to-end in a light functional run with `python OUT/code/mcl_plane_suite.py --in IN --out OUT --mode once --cycles 1 --stable-n 1 --eps 0 --adversarial false --web false --max-files 5 --hash-files false`, which completed and produced a run under `OUT/RUNS` (reported `[OK] Run complete`).
- Re-ran `python -m py_compile OUT/code/mcl_plane_suite.py` after final timestamp and CSV/header changes, which also succeeded.
- No automated tests were modified for the new `LITIGATIONOS_DRIVE_BUCKET_FORGER_v2026_01_27D.py` or PowerShell script in this PR; the Python suite functional run above validated integration points (inventory, evidence index, run manifest, and CSV outputs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697898ea40188322a3ed6168a47ca043)